### PR TITLE
Update Compose compiler for Kotlin 1.9.22

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -22,7 +22,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.3'
+        kotlinCompilerExtensionVersion '1.5.10'
     }
 
     kotlinOptions {


### PR DESCRIPTION
## Summary
- align Jetpack Compose compiler with Kotlin 1.9.22 by using version 1.5.10

## Testing
- `gradle test` *(fails: stalls while resolving configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68c3cf04a5108320bf3e84f68febe694