### PR TITLE
Add Material icons extended dependency to fix NoteAdd reference

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation 'androidx.compose.ui:ui'
     implementation 'androidx.compose.ui:ui-tooling-preview'
     implementation 'androidx.compose.material:material'
+    implementation 'androidx.compose.material:material-icons-extended'
     implementation 'androidx.navigation:navigation-compose:2.7.7'
     implementation 'io.coil-kt:coil-compose:2.5.0'
     implementation 'androidx.activity:activity-compose:1.8.2'


### PR DESCRIPTION
## Summary
- add `material-icons-extended` dependency to allow use of `Icons.Default.NoteAdd`

## Testing
- `gradle test --no-daemon --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68c3d1ec2a1c83209ddf6b451d3afa84