### PR TITLE
Add Android CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -1,0 +1,61 @@
+name: Android CI (StarbuckNoteTaker)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          cmdline-tools-version: 13114758
+          packages: >-
+            platform-tools
+            platforms;android-34
+            build-tools;34.0.0
+
+      - name: Make Gradle wrapper executable
+        run: chmod +x ./gradlew
+
+      - name: Show Gradle version
+        run: ./gradlew --version
+
+      #- name: Decode keystore
+      #  run: |
+      #    mkdir -p app
+      #    echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > app/starbucknotetaker.jks
+
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug --no-daemon
+        env:
+          ANDROID_KEYSTORE_PATH: starbucknotetaker.jks
+          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
+          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+
+      - name: Rename APK with build version
+        run: |
+          mkdir -p build-out
+          VERSION_NAME="1.0.${GITHUB_RUN_NUMBER}"
+          cp app/build/outputs/apk/debug/app-debug.apk \
+            "build-out/StarbuckNoteTaker-${VERSION_NAME}.apk"
+
+      - name: Upload APK artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StarbuckNoteTaker-1.0.${{ github.run_number }}
+          path: build-out/StarbuckNoteTaker-1.0.${{ github.run_number }}.apk
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build StarbuckNoteTaker debug APK and upload artifact

## Testing
- `gradle tasks` *(fails: Unrecognized VM option 'MaxPermSize=2g')*

------
https://chatgpt.com/codex/tasks/task_e_68c3d5248054832081cc46a23ae7a082