### PR TITLE
Remove deprecated MaxPermSize option from Gradle JVM args

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,4 @@ org.gradle.configuration-cache=true
 android.useAndroidX=true
 android.enableJetifier=true
 
-org.gradle.jvmargs=-Xmx4g -XX:MaxPermSize=2g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary
- remove unsupported `-XX:MaxPermSize=2g` flag from `org.gradle.jvmargs`

## Testing
- `./gradlew --console=plain test`


------
https://chatgpt.com/codex/tasks/task_e_68c3db33f7b48320bae4d6333b0b177f