### PR TITLE
Add swipe deletion and pincode lock

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -12,27 +12,46 @@ import androidx.navigation.compose.rememberNavController
 import com.example.starbucknotetaker.ui.AddNoteScreen
 import com.example.starbucknotetaker.ui.NoteDetailScreen
 import com.example.starbucknotetaker.ui.NoteListScreen
+import com.example.starbucknotetaker.ui.PinEnterScreen
+import com.example.starbucknotetaker.ui.PinSetupScreen
 
 class MainActivity : ComponentActivity() {
     private val noteViewModel: NoteViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val pinManager = PinManager(applicationContext)
         setContent {
             val navController = rememberNavController()
-            AppContent(navController, noteViewModel)
+            AppContent(navController, noteViewModel, pinManager)
         }
     }
 }
 
 @Composable
-fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel) {
-    NavHost(navController = navController, startDestination = "list") {
+fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, pinManager: PinManager) {
+    val start = if (pinManager.isPinSet()) "pin_enter" else "pin_setup"
+    NavHost(navController = navController, startDestination = start) {
+        composable("pin_setup") {
+            PinSetupScreen(pinManager = pinManager) {
+                navController.navigate("list") {
+                    popUpTo("pin_setup") { inclusive = true }
+                }
+            }
+        }
+        composable("pin_enter") {
+            PinEnterScreen(pinManager = pinManager) {
+                navController.navigate("list") {
+                    popUpTo("pin_enter") { inclusive = true }
+                }
+            }
+        }
         composable("list") {
             NoteListScreen(
                 notes = noteViewModel.notes,
                 onAddNote = { navController.navigate("add") },
-                onOpenNote = { index -> navController.navigate("detail/$index") }
+                onOpenNote = { index -> navController.navigate("detail/$index") },
+                onDeleteNote = { index -> noteViewModel.deleteNote(index) }
             )
         }
         composable("add") {

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -27,4 +27,10 @@ class NoteViewModel : ViewModel() {
         )
         _notes.add(0, note) // newest first
     }
+
+    fun deleteNote(index: Int) {
+        if (index in _notes.indices) {
+            _notes.removeAt(index)
+        }
+    }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
@@ -1,0 +1,16 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import android.content.SharedPreferences
+
+class PinManager(context: Context) {
+    private val prefs: SharedPreferences = context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
+
+    fun isPinSet(): Boolean = prefs.contains("pin")
+
+    fun setPin(pin: String) {
+        prefs.edit().putString("pin", pin).apply()
+    }
+
+    fun checkPin(pin: String): Boolean = prefs.getString("pin", null) == pin
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -1,11 +1,13 @@
 package com.example.starbucknotetaker.ui
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.NoteAdd
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -18,11 +20,13 @@ import com.example.starbucknotetaker.Note
 import java.text.SimpleDateFormat
 import java.util.Locale
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun NoteListScreen(
     notes: List<Note>,
     onAddNote: () -> Unit,
-    onOpenNote: (Int) -> Unit
+    onOpenNote: (Int) -> Unit,
+    onDeleteNote: (Int) -> Unit
 ) {
     var query by remember { mutableStateOf("") }
     val filtered = remember(query, notes) {
@@ -53,9 +57,33 @@ fun NoteListScreen(
                     .padding(8.dp)
             )
             LazyColumn(modifier = Modifier.fillMaxSize()) {
-                itemsIndexed(filtered) { _, note ->
+                itemsIndexed(filtered, key = { _, note -> note.id }) { _, note ->
                     val originalIndex = notes.indexOf(note)
-                    NoteListItem(note = note, onClick = { onOpenNote(originalIndex) })
+                    val dismissState = rememberDismissState(confirmStateChange = { value ->
+                        if (value == DismissValue.DismissedToStart) {
+                            onDeleteNote(originalIndex)
+                        }
+                        true
+                    })
+                    SwipeToDismiss(
+                        state = dismissState,
+                        background = {
+                            val color = if (dismissState.targetValue == DismissValue.Default) Color.Transparent else Color.Red
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(color)
+                                    .padding(horizontal = 20.dp),
+                                contentAlignment = Alignment.CenterEnd
+                            ) {
+                                Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.White)
+                            }
+                        },
+                        directions = setOf(DismissDirection.EndToStart),
+                        dismissContent = {
+                            NoteListItem(note = note, onClick = { onOpenNote(originalIndex) })
+                        }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -1,0 +1,89 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.material.Button
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.foundation.text.KeyboardOptions
+import com.example.starbucknotetaker.PinManager
+
+@Composable
+fun PinSetupScreen(pinManager: PinManager, onDone: () -> Unit) {
+    var pin by remember { mutableStateOf("") }
+    var confirmPin by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        OutlinedTextField(
+            value = pin,
+            onValueChange = { pin = it },
+            label = { Text("Enter PIN") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+        )
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedTextField(
+            value = confirmPin,
+            onValueChange = { confirmPin = it },
+            label = { Text("Confirm PIN") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+        )
+        if (error) {
+            Text("PINs do not match", color = Color.Red, modifier = Modifier.padding(top = 8.dp))
+        }
+        Button(onClick = {
+            if (pin.isNotEmpty() && pin == confirmPin) {
+                pinManager.setPin(pin)
+                onDone()
+            } else {
+                error = true
+            }
+        }, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Save")
+        }
+    }
+}
+
+@Composable
+fun PinEnterScreen(pinManager: PinManager, onSuccess: () -> Unit) {
+    var pin by remember { mutableStateOf("") }
+    var error by remember { mutableStateOf(false) }
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(16.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        OutlinedTextField(
+            value = pin,
+            onValueChange = { pin = it },
+            label = { Text("Enter PIN") },
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword)
+        )
+        if (error) {
+            Text("Incorrect PIN", color = Color.Red, modifier = Modifier.padding(top = 8.dp))
+        }
+        Button(onClick = {
+            if (pinManager.checkPin(pin)) {
+                onSuccess()
+            } else {
+                error = true
+            }
+        }, modifier = Modifier.padding(top = 16.dp)) {
+            Text("Unlock")
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- enable swipe-left note deletion with a red trash background
- add PIN setup and unlock screens stored via PinManager
- require PIN entry before accessing the note list

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c3e00901ec8320befbc46b0e2eff91