### PR TITLE
Improve PIN setup, note deletion, and branding

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">StarbuckNoteTaker</string>
+    <string name="app_name">Starbuck Notes</string>
 </resources>


### PR DESCRIPTION
## Summary
- Rename app to **Starbuck Notes**
- Revamp PIN setup and entry with numeric keypad, confirmation flow, and masked digits
- Swipe notes left to reveal a trash icon before deleting; group notes by day

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c3e68d0f808320b4836625263e32d4