### PR TITLE
feat(ci): sign apk with persistent key

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,19 +38,21 @@ jobs:
       #    mkdir -p app
       #    echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > app/starbuckstreamer.jks
 
-      - name: Build Debug APK
-        run: ./gradlew assembleDebug --no-daemon
+      - name: Build Release APK
+        run: ./gradlew assembleRelease --no-daemon
         env:
-          ANDROID_KEYSTORE_PATH: starbuckstreamer.jks
+          ANDROID_KEYSTORE_PATH: app/starbuckstreamer.jks
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
+          ANDROID_VERSION_CODE: ${{ github.run_number }}
+          ANDROID_VERSION_NAME: 1.0.${{ github.run_number }}
 
       - name: Rename APK with build version
         run: |
           mkdir -p build-out
           VERSION_NAME="1.0.${GITHUB_RUN_NUMBER}"
-          cp app/build/outputs/apk/debug/app-debug.apk \
+          cp app/build/outputs/apk/release/app-release.apk \
             "build-out/StarbuckNoteTaker-${VERSION_NAME}.apk"
 
       - name: Upload APK artifact

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -11,10 +11,36 @@ android {
         applicationId 'com.example.starbucknotetaker'
         minSdk 24
         targetSdk 34
-        versionCode 1
-        versionName '1.0'
+        versionCode System.getenv("ANDROID_VERSION_CODE")?.toInteger() ?: 1
+        versionName System.getenv("ANDROID_VERSION_NAME") ?: '1.0'
 
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+    }
+
+    signingConfigs {
+        release {
+            def keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
+            if (keystorePath) {
+                storeFile file(keystorePath)
+                storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
+                keyAlias System.getenv("ANDROID_KEY_ALIAS")
+                keyPassword System.getenv("ANDROID_KEY_PASSWORD")
+            }
+        }
+    }
+
+    buildTypes {
+        release {
+            if (signingConfigs.release.storeFile != null) {
+                signingConfig signingConfigs.release
+            }
+            minifyEnabled false
+        }
+        debug {
+            if (signingConfigs.release.storeFile != null) {
+                signingConfig signingConfigs.release
+            }
+        }
     }
 
     buildFeatures {


### PR DESCRIPTION
## Summary
- use environment-provided version code/name and keystore for release signing
- build release APK in CI using project keystore and run number

## Testing
- `ANDROID_VERSION_CODE=2 ANDROID_VERSION_NAME=1.0.2 ./gradlew assembleRelease`

------
https://chatgpt.com/codex/tasks/task_e_68c3e785896083209c1ba81744c50849