### PR TITLE
Improve swipe action and PIN entry UI

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -1,12 +1,16 @@
 package com.example.starbucknotetaker.ui
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.material.swipeable
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.*
+import androidx.compose.material.DismissDirection
+import androidx.compose.material.DismissValue
+import androidx.compose.material.FractionalThreshold
+import androidx.compose.material.SwipeToDismiss
+import androidx.compose.material.rememberDismissState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.NoteAdd
@@ -16,12 +20,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.Note
 import java.text.SimpleDateFormat
 import java.util.*
-import kotlin.math.roundToInt
 
 @Composable
 fun NoteListScreen(
@@ -83,38 +85,44 @@ private fun SwipeToDeleteNoteItem(
     onClick: () -> Unit,
     onDelete: () -> Unit
 ) {
-    BoxWithConstraints {
-        val width = constraints.maxWidth.toFloat()
-        val swipeState = rememberSwipeableState(0)
-        val maxSwipe = width * 0.2f
-        val anchors = mapOf(0f to 0, -maxSwipe to 1)
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .swipeable(
-                    state = swipeState,
-                    anchors = anchors,
-                    orientation = Orientation.Horizontal,
-                    thresholds = { _, _ -> FractionalThreshold(0.3f) }
-                )
-        ) {
-            Box(
+    val dismissState = rememberDismissState(
+        confirmStateChange = { value ->
+            if (value == DismissValue.DismissedToStart) {
+                onDelete()
+            }
+            false
+        }
+    )
+    SwipeToDismiss(
+        state = dismissState,
+        directions = setOf(DismissDirection.EndToStart),
+        dismissThresholds = { FractionalThreshold(0.5f) },
+        background = {
+            Row(
                 modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.CenterEnd
+                    .fillMaxSize()
+                    .background(Color.Red)
+                    .padding(horizontal = 16.dp),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(onClick = onDelete) {
-                    Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.Red)
+                    Icon(
+                        Icons.Default.Delete,
+                        contentDescription = "Delete",
+                        tint = Color.White
+                    )
                 }
             }
+        },
+        dismissContent = {
             NoteListItem(
                 note = note,
                 showDate = showDate,
-                onClick = onClick,
-                modifier = Modifier.offset { IntOffset(swipeState.offset.value.roundToInt(), 0) }
+                onClick = onClick
             )
         }
-    }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -1,10 +1,13 @@
 package com.example.starbucknotetaker.ui
 
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.background
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.Button
 import androidx.compose.material.OutlinedTextField
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
+import androidx.compose.material.TextFieldDefaults
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -124,12 +127,15 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: () -> Unit) {
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     Column(
-        modifier = Modifier.fillMaxSize().padding(16.dp),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White)
+            .padding(16.dp),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text("Please enter your PIN.", modifier = Modifier.padding(bottom = 16.dp))
-        OutlinedTextField(
+        TextField(
             value = pin,
             onValueChange = { input ->
                 if (input.length <= 6 && input.all { it.isDigit() }) {
@@ -142,7 +148,13 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: () -> Unit) {
             singleLine = true,
             textStyle = androidx.compose.material.LocalTextStyle.current.copy(
                 textAlign = TextAlign.Center,
-                fontSize = 32.sp
+                fontSize = 64.sp
+            ),
+            colors = TextFieldDefaults.textFieldColors(
+                backgroundColor = Color.Transparent,
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+                textColor = Color.Black
             ),
             modifier = Modifier
                 .width(200.dp)


### PR DESCRIPTION
## Summary
- Show a red trash action when swiping notes to the left
- Simplify PIN entry with white background and large, borderless digits

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c3eb5fe9008320b4ab66afa8494abc