### PR TITLE
Fix keystore path handling for release signing

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,7 +21,8 @@ android {
         release {
             def keystorePath = System.getenv("ANDROID_KEYSTORE_PATH")
             if (keystorePath) {
-                storeFile file(keystorePath)
+                def keyFile = keystorePath.startsWith("/") ? file(keystorePath) : rootProject.file(keystorePath)
+                storeFile keyFile
                 storePassword System.getenv("ANDROID_KEYSTORE_PASSWORD")
                 keyAlias System.getenv("ANDROID_KEY_ALIAS")
                 keyPassword System.getenv("ANDROID_KEY_PASSWORD")


### PR DESCRIPTION
## Summary
- Resolve release keystore path relative to project root
- Handle absolute keystore paths gracefully

## Testing
- `./gradlew assembleDebug`


------
https://chatgpt.com/codex/tasks/task_e_68c3f01677c48320a1532b9b4e28e467