### PR TITLE
Build debug APK in CI

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -38,26 +38,19 @@ jobs:
       #    mkdir -p app
       #    echo "$ANDROID_KEYSTORE_BASE64" | base64 --decode > app/starbuckstreamer.jks
 
-      - name: Build Release APK
-        run: ./gradlew assembleRelease --no-daemon
-        env:
-          ANDROID_KEYSTORE_PATH: app/starbuckstreamer.jks
-          ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
-          ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-          ANDROID_VERSION_CODE: ${{ github.run_number }}
-          ANDROID_VERSION_NAME: 1.0.${{ github.run_number }}
+      - name: Build Debug APK
+        run: ./gradlew assembleDebug --no-daemon
 
       - name: Rename APK with build version
         run: |
           mkdir -p build-out
           VERSION_NAME="1.0.${GITHUB_RUN_NUMBER}"
-          cp app/build/outputs/apk/release/app-release.apk \
-            "build-out/StarbuckNoteTaker-${VERSION_NAME}.apk"
+          cp app/build/outputs/apk/debug/app-debug.apk \
+            "build-out/StarbuckNoteTaker-${VERSION_NAME}-debug.apk"
 
       - name: Upload APK artifact
         uses: actions/upload-artifact@v4
         with:
-          name: StarbuckNoteTaker-1.0.${{ github.run_number }}
-          path: build-out/StarbuckNoteTaker-1.0.${{ github.run_number }}.apk
+          name: StarbuckNoteTaker-1.0.${{ github.run_number }}-debug
+          path: build-out/StarbuckNoteTaker-1.0.${{ github.run_number }}-debug.apk
           if-no-files-found: error


### PR DESCRIPTION
## Summary
- build debug APK instead of release in GitHub Actions
- drop signing requirements and upload debug artifact

## Testing
- `./gradlew assembleDebug`

------
https://chatgpt.com/codex/tasks/task_e_68c3f4b50e4c8320bc0421db8c60bfee