### PR TITLE
Encrypt notes with PIN

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -1,0 +1,85 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import android.net.Uri
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.security.SecureRandom
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+class EncryptedNoteStore(private val context: Context) {
+    private val file = File(context.filesDir, "notes.enc")
+
+    fun loadNotes(pin: String): List<Note> {
+        if (!file.exists()) return emptyList()
+        val bytes = file.readBytes()
+        if (bytes.size < 28) return emptyList()
+        val salt = bytes.copyOfRange(0, 16)
+        val iv = bytes.copyOfRange(16, 28)
+        val cipherText = bytes.copyOfRange(28, bytes.size)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val key = deriveKey(pin, salt)
+        cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val json = String(cipher.doFinal(cipherText), Charsets.UTF_8)
+        val arr = JSONArray(json)
+        val notes = mutableListOf<Note>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            val imagesJson = obj.optJSONArray("images") ?: JSONArray()
+            val images = mutableListOf<Uri>()
+            for (j in 0 until imagesJson.length()) {
+                images.add(Uri.parse(imagesJson.getString(j)))
+            }
+            notes.add(
+                Note(
+                    id = obj.getLong("id"),
+                    title = obj.getString("title"),
+                    content = obj.getString("content"),
+                    date = obj.getLong("date"),
+                    images = images
+                )
+            )
+        }
+        return notes
+    }
+
+    fun saveNotes(notes: List<Note>, pin: String) {
+        val arr = JSONArray()
+        notes.forEach { note ->
+            val obj = JSONObject()
+            obj.put("id", note.id)
+            obj.put("title", note.title)
+            obj.put("content", note.content)
+            obj.put("date", note.date)
+            val imagesArray = JSONArray()
+            note.images.forEach { imagesArray.put(it.toString()) }
+            obj.put("images", imagesArray)
+            arr.put(obj)
+        }
+        val json = arr.toString().toByteArray(Charsets.UTF_8)
+        val salt = ByteArray(16).also { SecureRandom().nextBytes(it) }
+        val iv = ByteArray(12).also { SecureRandom().nextBytes(it) }
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val key = deriveKey(pin, salt)
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val cipherText = cipher.doFinal(json)
+        val output = ByteArray(16 + 12 + cipherText.size)
+        System.arraycopy(salt, 0, output, 0, 16)
+        System.arraycopy(iv, 0, output, 16, 12)
+        System.arraycopy(cipherText, 0, output, 28, cipherText.size)
+        file.writeBytes(output)
+    }
+
+    private fun deriveKey(pin: String, salt: ByteArray): SecretKeySpec {
+        val spec = PBEKeySpec(pin.toCharArray(), salt, 10000, 256)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val bytes = factory.generateSecret(spec).encoded
+        return SecretKeySpec(bytes, "AES")
+    }
+}
+

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -5,6 +5,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -31,16 +32,19 @@ class MainActivity : ComponentActivity() {
 @Composable
 fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, pinManager: PinManager) {
     val start = if (pinManager.isPinSet()) "pin_enter" else "pin_setup"
+    val context = LocalContext.current
     NavHost(navController = navController, startDestination = start) {
         composable("pin_setup") {
-            PinSetupScreen(pinManager = pinManager) {
+            PinSetupScreen(pinManager = pinManager) { pin ->
+                noteViewModel.loadNotes(context, pin)
                 navController.navigate("list") {
                     popUpTo("pin_setup") { inclusive = true }
                 }
             }
         }
         composable("pin_enter") {
-            PinEnterScreen(pinManager = pinManager) {
+            PinEnterScreen(pinManager = pinManager) { pin ->
+                noteViewModel.loadNotes(context, pin)
                 navController.navigate("list") {
                     popUpTo("pin_enter") { inclusive = true }
                 }

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -1,5 +1,6 @@
 package com.example.starbucknotetaker
 
+import android.content.Context
 import android.net.Uri
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
@@ -12,6 +13,16 @@ class NoteViewModel : ViewModel() {
     val notes: List<Note> = _notes
 
     private var untitledCounter = 1
+    private var pin: String? = null
+    private var store: EncryptedNoteStore? = null
+
+    fun loadNotes(context: Context, pin: String) {
+        this.pin = pin
+        val s = EncryptedNoteStore(context)
+        store = s
+        _notes.clear()
+        _notes.addAll(s.loadNotes(pin))
+    }
 
     fun addNote(title: String?, content: String, images: List<Uri>) {
         val finalTitle = if (title.isNullOrBlank()) {
@@ -26,11 +37,13 @@ class NoteViewModel : ViewModel() {
             images = images
         )
         _notes.add(0, note) // newest first
+        pin?.let { store?.saveNotes(_notes, it) }
     }
 
     fun deleteNote(index: Int) {
         if (index in _notes.indices) {
             _notes.removeAt(index)
+            pin?.let { store?.saveNotes(_notes, it) }
         }
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -37,7 +37,7 @@ private class PinVisualTransformation(private val revealLast: Boolean) : VisualT
 }
 
 @Composable
-fun PinSetupScreen(pinManager: PinManager, onDone: () -> Unit) {
+fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
     var pin by remember { mutableStateOf("") }
     var firstPin by remember { mutableStateOf<String?>(null) }
     var error by remember { mutableStateOf<String?>(null) }
@@ -97,7 +97,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: () -> Unit) {
                 } else {
                     if (pin == firstPin) {
                         pinManager.setPin(pin)
-                        onDone()
+                        onDone(pin)
                     } else {
                         error = "PINs do not match"
                         pin = ""
@@ -112,7 +112,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: () -> Unit) {
 }
 
 @Composable
-fun PinEnterScreen(pinManager: PinManager, onSuccess: () -> Unit) {
+fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
     var pin by remember { mutableStateOf("") }
     var error by remember { mutableStateOf(false) }
     var reveal by remember { mutableStateOf(false) }
@@ -166,7 +166,7 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: () -> Unit) {
         Button(
             onClick = {
                 if (pin.length in 4..6 && pinManager.checkPin(pin)) {
-                    onSuccess()
+                    onSuccess(pin)
                 } else {
                     error = true
                 }


### PR DESCRIPTION
## Summary
- encrypt persisted notes with AES-GCM using a key derived from the user's PIN
- load and save notes through a new EncryptedNoteStore
- propagate PIN from setup/unlock screens so notes unlock on successful entry

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c3fd3527d0832086b841b8ebdf38b1