### PR TITLE
Use narrow swipe delete background

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -113,18 +113,20 @@ private fun SwipeToDeleteNoteItem(
                 orientation = Orientation.Horizontal
             )
     ) {
-        Row(
+        Box(
             modifier = Modifier
-                .fillMaxSize()
+                .fillMaxHeight()
+                .width(actionWidth)
+                .align(Alignment.CenterEnd)
                 .background(Color.Red),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
+            contentAlignment = Alignment.Center
         ) {
-            IconButton(
-                onClick = onDelete,
-                modifier = Modifier.width(actionWidth)
-            ) {
-                Icon(Icons.Default.Delete, contentDescription = "Delete", tint = Color.White)
+            IconButton(onClick = onDelete) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = "Delete",
+                    tint = Color.White
+                )
             }
         }
         NoteListItem(


### PR DESCRIPTION
## Summary
- Limit swipe delete background to a narrow red strip
- Delete button sits in constrained Box and triggers note removal

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c4c7ab3064832091e08cb2d249ee76