### PR TITLE
Improve delete interaction and PIN setup screen

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -122,7 +122,9 @@ private fun SwipeToDeleteNoteItem(
                 .background(Color.Red),
             contentAlignment = Alignment.Center
         ) {
-            IconButton(onClick = onDelete) {
+            IconButton(onClick = {
+                scope.launch { swipeState.animateTo(2) }
+            }) {
                 Icon(
                     Icons.Default.Delete,
                     contentDescription = "Delete",

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -52,7 +52,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     val message = if (firstPin == null) {
-        "This is the first time you've accessed this application. Please set a one-time PIN of 4 to 6 characters."
+        "Create a custom PIN"
     } else {
         "Please confirm your PIN."
     }
@@ -79,7 +79,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
             singleLine = true,
             textStyle = androidx.compose.material.LocalTextStyle.current.copy(
                 textAlign = TextAlign.Center,
-                fontSize = 32.sp
+                fontSize = 64.sp
             ),
             colors = TextFieldDefaults.textFieldColors(
                 backgroundColor = Color.Transparent,


### PR DESCRIPTION
## Summary
- Ensure trash icon animates away along with its note when deleting
- Enlarge PIN setup text field and update initial prompt

## Testing
- `./gradlew test`
- `./gradlew lint`


------
https://chatgpt.com/codex/tasks/task_e_68c4eeb1576c8320914b8e15b0d94898