### PR TITLE
Ensure secure note handling and embedded images

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -1,7 +1,6 @@
 package com.example.starbucknotetaker
 
 import android.content.Context
-import android.net.Uri
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File
@@ -31,9 +30,9 @@ class EncryptedNoteStore(private val context: Context) {
         for (i in 0 until arr.length()) {
             val obj = arr.getJSONObject(i)
             val imagesJson = obj.optJSONArray("images") ?: JSONArray()
-            val images = mutableListOf<Uri>()
+            val images = mutableListOf<String>()
             for (j in 0 until imagesJson.length()) {
-                images.add(Uri.parse(imagesJson.getString(j)))
+                images.add(imagesJson.getString(j))
             }
             notes.add(
                 Note(
@@ -57,7 +56,7 @@ class EncryptedNoteStore(private val context: Context) {
             obj.put("content", note.content)
             obj.put("date", note.date)
             val imagesArray = JSONArray()
-            note.images.forEach { imagesArray.put(it.toString()) }
+            note.images.forEach { imagesArray.put(it) }
             obj.put("images", imagesArray)
             arr.put(obj)
         }

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -1,7 +1,5 @@
 package com.example.starbucknotetaker
 
-import android.net.Uri
-
 /**
  * Represents a note with title, textual content, creation date and optional images.
  */
@@ -10,5 +8,5 @@ data class Note(
     val title: String,
     val content: String,
     val date: Long = System.currentTimeMillis(),
-    val images: List<Uri> = emptyList()
+    val images: List<String> = emptyList()
 )

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -1,7 +1,9 @@
 package com.example.starbucknotetaker.ui
 
 import android.content.Intent
+import android.graphics.BitmapFactory
 import android.net.Uri
+import android.util.Base64
 import android.util.Patterns
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
@@ -10,19 +12,19 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.ClickableText
+import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.*
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
-import coil.compose.rememberAsyncImagePainter
 import com.example.starbucknotetaker.Note
 
 @Composable
@@ -46,33 +48,24 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit) {
             lines.forEach { line ->
                 val trimmed = line.trim()
                 val placeholder = Regex("\\[\\[image:(\\d+)]]").matchEntire(trimmed)
-                when {
-                    placeholder != null -> {
-                        val index = placeholder.groupValues[1].toInt()
-                        note.images.getOrNull(index)?.let { uri ->
-                            Image(
-                                painter = rememberAsyncImagePainter(uri),
-                                contentDescription = null,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(bottom = 8.dp)
-                            )
-                        }
-                    }
-                    isImageUrl(trimmed) -> {
+                if (placeholder != null) {
+                    val index = placeholder.groupValues[1].toInt()
+                    note.images.getOrNull(index)?.let { base64 ->
+                        val bytes = remember(base64) { Base64.decode(base64, Base64.DEFAULT) }
+                        val bitmap = remember(bytes) { BitmapFactory.decodeByteArray(bytes, 0, bytes.size) }
                         Image(
-                            painter = rememberAsyncImagePainter(trimmed),
+                            bitmap.asImageBitmap(),
                             contentDescription = null,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = 8.dp)
                         )
                     }
-                    else -> {
-                        val annotated = buildAnnotatedString {
-                            var lastIndex = 0
-                            val matcher = Patterns.WEB_URL.matcher(trimmed)
-                            while (matcher.find()) {
+                } else {
+                    val annotated = buildAnnotatedString {
+                        var lastIndex = 0
+                        val matcher = Patterns.WEB_URL.matcher(trimmed)
+                        while (matcher.find()) {
                                 val start = matcher.start()
                                 val end = matcher.end()
                                 append(trimmed.substring(lastIndex, start))
@@ -96,15 +89,8 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit) {
                             },
                             modifier = Modifier.padding(bottom = 8.dp)
                         )
-                    }
                 }
             }
         }
     }
-}
-
-private fun isImageUrl(url: String): Boolean {
-    val lower = url.lowercase()
-    return Patterns.WEB_URL.matcher(url).matches() &&
-            (lower.endsWith(".png") || lower.endsWith(".jpg") || lower.endsWith(".jpeg") || lower.endsWith(".gif") || lower.endsWith(".bmp") || lower.endsWith(".webp"))
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -61,8 +61,9 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
         modifier = Modifier
             .fillMaxSize()
             .background(Color.White)
-            .padding(16.dp),
-        verticalArrangement = Arrangement.Center,
+            .padding(16.dp)
+            .imePadding(),
+        verticalArrangement = Arrangement.Top,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         Text(message, modifier = Modifier.padding(bottom = 16.dp))


### PR DESCRIPTION
## Summary
- Require PIN re-entry after app backgrounding for improved security
- Embed note images directly in encrypted storage and render from base64
- Refine swipe-to-delete so only one row exposes a trash icon and deletion occurs on confirmation
- Adjust PIN setup layout to keep confirmation button above the keyboard

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c537d50e688320a0d0637a18b66ac9