### PR TITLE
feat: update theme color and pause pin check when importing images

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -37,11 +37,12 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
     val start = if (pinManager.isPinSet()) "pin_enter" else "pin_setup"
     val context = LocalContext.current
     var requireAuth by remember { mutableStateOf(false) }
+    var pinCheckEnabled by remember { mutableStateOf(true) }
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_STOP) {
+            if (event == Lifecycle.Event.ON_STOP && pinCheckEnabled) {
                 requireAuth = true
             }
         }
@@ -85,10 +86,15 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             )
         }
         composable("add") {
-            AddNoteScreen(onSave = { title, content, images ->
-                noteViewModel.addNote(title, content, images)
-                navController.popBackStack()
-            }, onBack = { navController.popBackStack() })
+            AddNoteScreen(
+                onSave = { title, content, images ->
+                    noteViewModel.addNote(title, content, images)
+                    navController.popBackStack()
+                },
+                onBack = { navController.popBackStack() },
+                onDisablePinCheck = { pinCheckEnabled = false },
+                onEnablePinCheck = { pinCheckEnabled = true }
+            )
         }
         composable("detail/{index}") { backStackEntry ->
             val index = backStackEntry.arguments?.getString("index")?.toIntOrNull() ?: 0

--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -23,7 +23,9 @@ import coil.compose.rememberAsyncImagePainter
 @Composable
 fun AddNoteScreen(
     onSave: (String?, String, List<Uri>) -> Unit,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onDisablePinCheck: () -> Unit,
+    onEnablePinCheck: () -> Unit
 ) {
     var title by remember { mutableStateOf("") }
     val blocks = remember { mutableStateListOf<NoteBlock>(NoteBlock.Text("")) }
@@ -31,6 +33,7 @@ fun AddNoteScreen(
     val context = LocalContext.current
 
     val launcher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+        onEnablePinCheck()
         uri?.let {
             context.contentResolver.takePersistableUriPermission(
                 it,
@@ -40,6 +43,10 @@ fun AddNoteScreen(
             blocks.add(NoteBlock.Image(it))
             blocks.add(NoteBlock.Text(""))
         }
+    }
+
+    DisposableEffect(Unit) {
+        onDispose { onEnablePinCheck() }
     }
 
     Scaffold(
@@ -122,7 +129,10 @@ fun AddNoteScreen(
             }
             item {
                 OutlinedButton(
-                    onClick = { launcher.launch(arrayOf("image/*")) },
+                    onClick = {
+                        onDisablePinCheck()
+                        launcher.launch(arrayOf("image/*"))
+                    },
                     modifier = Modifier
                         .padding(top = 8.dp)
                         .fillMaxWidth()

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.colorResource
+import com.example.starbucknotetaker.R
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,7 +45,7 @@ fun NoteListScreen(
         floatingActionButton = {
             FloatingActionButton(
                 onClick = onAddNote,
-                backgroundColor = Color(0xFF4CAF50)
+                backgroundColor = colorResource(id = R.color.fab_color)
             ) {
                 Icon(Icons.Default.NoteAdd, contentDescription = "Add note", tint = Color.White)
             }

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <resources>
-    <color name="green_fab">#4CAF50</color>
-    <color name="ic_launcher_background">#4CAF50</color>
+    <color name="fab_color">#EC1A55</color>
+    <color name="ic_launcher_background">#EC1A55</color>
 </resources>


### PR DESCRIPTION
## Summary
- switch app's baseline color to #EC1A55 and apply to FAB
- temporarily disable PIN re-entry when launching image picker and re-enable on return

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c53e7903f483208ad340a6ad6aa4c2