### PR TITLE
Add image rotation and status bar theming

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -75,6 +75,7 @@ dependencies {
     implementation 'io.coil-kt:coil-compose:2.5.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
+    implementation 'androidx.exifinterface:exifinterface:1.3.7'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -126,28 +126,34 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
                 ) {
                     Icon(Icons.Default.Close, contentDescription = "Close", tint = Color.White)
                 }
-                IconButton(
-                    onClick = {
-                        val bytesToSave = Base64.decode(img, Base64.DEFAULT)
-                        val name = "note_image_${System.currentTimeMillis()}.png"
-                        val values = ContentValues().apply {
-                            put(MediaStore.Images.Media.DISPLAY_NAME, name)
-                            put(MediaStore.Images.Media.MIME_TYPE, "image/png")
-                        }
-                        val uri = context.contentResolver.insert(
-                            MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
-                            values
-                        )
-                        uri?.let {
-                            context.contentResolver.openOutputStream(it)?.use { out ->
-                                out.write(bytesToSave)
+                var menuExpanded by remember { mutableStateOf(false) }
+                Box(modifier = Modifier.align(Alignment.TopEnd)) {
+                    IconButton(onClick = { menuExpanded = true }) {
+                        Icon(Icons.Default.MoreVert, contentDescription = "Menu", tint = Color.White)
+                    }
+                    DropdownMenu(expanded = menuExpanded, onDismissRequest = { menuExpanded = false }) {
+                        DropdownMenuItem(onClick = {
+                            val bytesToSave = Base64.decode(img, Base64.DEFAULT)
+                            val name = "note_image_${System.currentTimeMillis()}.png"
+                            val values = ContentValues().apply {
+                                put(MediaStore.Images.Media.DISPLAY_NAME, name)
+                                put(MediaStore.Images.Media.MIME_TYPE, "image/png")
                             }
-                            Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
+                            val uri = context.contentResolver.insert(
+                                MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
+                                values
+                            )
+                            uri?.let {
+                                context.contentResolver.openOutputStream(it)?.use { out ->
+                                    out.write(bytesToSave)
+                                }
+                                Toast.makeText(context, "Image saved", Toast.LENGTH_SHORT).show()
+                            }
+                            menuExpanded = false
+                        }) {
+                            Text("Save image")
                         }
-                    },
-                    modifier = Modifier.align(Alignment.TopEnd)
-                ) {
-                    Icon(Icons.Default.MoreVert, contentDescription = "Save", tint = Color.White)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/Theme.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/Theme.kt
@@ -5,7 +5,12 @@ import androidx.compose.material.MaterialTheme
 import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowInsetsControllerCompat
+import android.app.Activity
 
 private val Pink = Color(0xFFEC1A55)
 
@@ -23,7 +28,16 @@ private val DarkColors = darkColors(
 
 @Composable
 fun StarbuckNoteTakerTheme(content: @Composable () -> Unit) {
-    val colors = if (isSystemInDarkTheme()) DarkColors else LightColors
+    val darkTheme = isSystemInDarkTheme()
+    val colors = if (darkTheme) DarkColors else LightColors
+    val view = LocalView.current
+    if (!view.isInEditMode) {
+        SideEffect {
+            val window = (view.context as Activity).window
+            window.statusBarColor = colors.primary.toArgb()
+            WindowInsetsControllerCompat(window, view).isAppearanceLightStatusBars = !darkTheme
+        }
+    }
     MaterialTheme(colors = colors, content = content)
 }
 


### PR DESCRIPTION
## Summary
- theme system status bar to match app colors
- prevent extra text field when image picker canceled
- support rotating images and merging adjacent text after removal
- add menu option to save images from viewer

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68c54868dd1483209c318e509bf6ac61