### PR TITLE
Restore screen after PIN and force light theme

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.*
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
@@ -26,6 +27,8 @@ class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
 
         val pinManager = PinManager(applicationContext)
         setContent {
@@ -57,9 +60,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
 
     LaunchedEffect(requireAuth) {
         if (requireAuth && navController.currentDestination?.route !in listOf("pin_enter", "pin_setup")) {
-            navController.navigate("pin_enter") {
-                popUpTo("pin_enter") { inclusive = true }
-            }
+            navController.navigate("pin_enter")
         }
     }
 
@@ -77,8 +78,12 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             PinEnterScreen(pinManager = pinManager) { pin ->
                 requireAuth = false
                 noteViewModel.loadNotes(context, pin)
-                navController.navigate("list") {
-                    popUpTo("pin_enter") { inclusive = true }
+                if (navController.previousBackStackEntry != null) {
+                    navController.popBackStack()
+                } else {
+                    navController.navigate("list") {
+                        popUpTo("pin_enter") { inclusive = true }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/Theme.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/Theme.kt
@@ -1,8 +1,6 @@
 package com.example.starbucknotetaker.ui
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material.MaterialTheme
-import androidx.compose.material.darkColors
 import androidx.compose.material.lightColors
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
@@ -20,24 +18,16 @@ private val LightColors = lightColors(
     secondary = Pink
 )
 
-private val DarkColors = darkColors(
-    primary = Pink,
-    primaryVariant = Pink,
-    secondary = Pink
-)
-
 @Composable
 fun StarbuckNoteTakerTheme(content: @Composable () -> Unit) {
-    val darkTheme = isSystemInDarkTheme()
-    val colors = if (darkTheme) DarkColors else LightColors
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
             val window = (view.context as Activity).window
-            window.statusBarColor = colors.primary.toArgb()
-            WindowInsetsControllerCompat(window, view).isAppearanceLightStatusBars = !darkTheme
+            window.statusBarColor = LightColors.primary.toArgb()
+            WindowInsetsControllerCompat(window, view).isAppearanceLightStatusBars = true
         }
     }
-    MaterialTheme(colors = colors, content = content)
+    MaterialTheme(colors = LightColors, content = content)
 }
 


### PR DESCRIPTION
## Summary
- Maintain navigation stack when app moves to background and return to previous screen after PIN entry
- Remove dark mode support and ensure light color scheme across the app

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c5705e458c8320960139dd19ed48f2