### PR TITLE
Download summarization models from releases on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,12 @@ This repository uses the included Gradle wrapper. Typical commands:
 
 ## On-device summarization models
 
-To enable the optional summarizer, download the TensorFlow Lite model files from the
-project's release page and place them in `app/src/main/assets/`:
+The app downloads its TensorFlow Lite summarisation models from the project's
+GitHub Releases on first run and caches them under internal storage. If the
+download fails, summaries gracefully fall back to a simple extractive method.
 
-- `encoder_int8_dynamic.tflite`
-- `decoder_step_int8_dynamic.tflite`
-- `spiece.model`
-
-Release downloads: https://github.com/nickprice101/StarbuckNoteTaker/releases/tag/v1.0.0
-
-These binaries are excluded from version control and must be added manually.
+The release asset URL and optional SHA-256 checksum are configured in
+`ModelFetcher`. Update these constants when publishing new model versions.
 
 ## Requirements
 

--- a/app/src/main/assets/README.md
+++ b/app/src/main/assets/README.md
@@ -1,16 +1,14 @@
 # Model assets
 
-This directory holds optional TensorFlow Lite and tokenizer files for on-device
-summarisation.
+This directory is intentionally left empty. On first run the application
+downloads the required TensorFlow Lite models from the project's GitHub
+Releases and stores them under the app's internal `files/models` directory.
 
-The following files are expected at runtime:
+If you prefer to bundle the models manually (for offline installs), place the
+following files here:
 
 - `encoder_int8_dynamic.tflite`
 - `decoder_step_int8_dynamic.tflite`
 - `spiece.model`
 
-Download them from the project's release page and place them in this folder:
-https://github.com/nickprice101/StarbuckNoteTaker/releases/tag/v1.0.0
-
-These binaries are not tracked in git; they must be added manually after
-cloning the repository.
+These binaries remain untracked by git.

--- a/app/src/main/java/com/example/starbucknotetaker/ModelFetcher.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ModelFetcher.kt
@@ -1,0 +1,109 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.io.File
+import java.io.FileOutputStream
+import java.security.MessageDigest
+import java.util.zip.ZipInputStream
+
+/**
+ * Downloads the summarization models from GitHub Releases on first run.
+ * The models are stored under `files/models` in the app's internal storage.
+ */
+object ModelFetcher {
+    // URL of the ZIP file hosted on the repo's Releases page
+    private const val ZIP_URL = "https://github.com/nickprice101/StarbuckNoteTaker/releases/download/v1.0.0/flan_t5_small_tflite_min.zip"
+    private const val ZIP_NAME = "flan_t5_small_tflite_min.zip"
+    // Optional SHA-256 of the ZIP for integrity checking
+    private const val ZIP_SHA256 = "PUT_SHA256_OF_ZIP_HERE"
+
+    // File names inside the ZIP archive
+    const val ENCODER_NAME = "flan_t5_small_tflite_min/encoder_int8_dynamic.tflite"
+    const val DECODER_NAME = "flan_t5_small_tflite_min/decoder_step_int8_dynamic.tflite"
+
+    private val client by lazy { OkHttpClient() }
+
+    /**
+     * Ensures the encoder and decoder models are present under `files/models` and returns
+     * their [File] locations. Downloads and unzips them if necessary.
+     */
+    suspend fun ensureModels(context: Context): Pair<File, File> = withContext(Dispatchers.IO) {
+        val modelsDir = File(context.filesDir, "models").apply { mkdirs() }
+        val encoderFile = File(modelsDir, "encoder_int8_dynamic.tflite")
+        val decoderFile = File(modelsDir, "decoder_step_int8_dynamic.tflite")
+
+        if (encoderFile.exists() && decoderFile.exists()) return@withContext encoderFile to decoderFile
+
+        val zipFile = File(context.cacheDir, ZIP_NAME)
+        download(ZIP_URL, zipFile)
+
+        if (ZIP_SHA256.isNotBlank()) {
+            val got = sha256(zipFile)
+            require(got.equals(ZIP_SHA256, ignoreCase = true)) {
+                "Model ZIP SHA-256 mismatch. expected=$ZIP_SHA256 got=$got"
+            }
+        }
+
+        unzipSelect(zipFile, modelsDir, setOf(ENCODER_NAME, DECODER_NAME))
+        require(encoderFile.exists() && decoderFile.exists()) { "Model files missing after unzip" }
+        zipFile.delete()
+        encoderFile to decoderFile
+    }
+
+    private fun download(url: String, dest: File) {
+        val req = Request.Builder().url(url).get().build()
+        client.newCall(req).execute().use { resp ->
+            if (!resp.isSuccessful) error("HTTP ${'$'}{resp.code}: ${'$'}url")
+            resp.body?.byteStream().use { ins ->
+                FileOutputStream(dest).use { out ->
+                    val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+                    while (true) {
+                        val read = ins?.read(buf) ?: -1
+                        if (read == -1) break
+                        out.write(buf, 0, read)
+                    }
+                }
+            }
+        }
+    }
+
+    private fun sha256(file: File): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { ins ->
+            val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val n = ins.read(buf)
+                if (n <= 0) break
+                md.update(buf, 0, n)
+            }
+        }
+        return md.digest().joinToString("") { "%02x".format(it) }
+    }
+
+    private fun unzipSelect(zip: File, dstDir: File, wanted: Set<String>) {
+        ZipInputStream(zip.inputStream()).use { zis ->
+            var entry = zis.nextEntry
+            while (entry != null) {
+                val name = entry.name
+                if (!entry.isDirectory && name in wanted) {
+                    val outFile = File(dstDir, name.substringAfterLast('/'))
+                    outFile.outputStream().use { out ->
+                        val buf = ByteArray(DEFAULT_BUFFER_SIZE)
+                        while (true) {
+                            val read = zis.read(buf)
+                            if (read == -1) break
+                            out.write(buf, 0, read)
+                        }
+                    }
+                }
+                zis.closeEntry()
+                entry = zis.nextEntry
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -3,41 +3,47 @@ package com.example.starbucknotetaker
 import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import java.io.FileInputStream
+import org.tensorflow.lite.Interpreter
+import java.io.File
+import java.io.RandomAccessFile
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
-import org.tensorflow.lite.Interpreter
 
 /**
  * Simple on-device text summarizer.
  *
- * The implementation attempts to load T5 encoder/decoder TFLite models from assets and
- * can be extended to run full sequence-to-sequence inference. Currently it falls back to a
+ * The implementation ensures T5 encoder/decoder TFLite models are downloaded on-demand
+ * and can be extended to run full sequence-to-sequence inference. Currently it falls back to a
  * lightweight extractive summary when the models cannot be used.
  */
 class Summarizer(private val context: Context) {
-    private val encoder: Interpreter? = loadModel("encoder_int8_dynamic.tflite")
-    private val decoder: Interpreter? = loadModel("decoder_step_int8_dynamic.tflite")
+    private var encoder: Interpreter? = null
+    private var decoder: Interpreter? = null
 
-    private fun loadModel(name: String): Interpreter? {
-        return try {
-            val fileDescriptor = context.assets.openFd(name)
-            FileInputStream(fileDescriptor.fileDescriptor).use { fis ->
-                val mapped: MappedByteBuffer =
-                    fis.channel.map(FileChannel.MapMode.READ_ONLY, fileDescriptor.startOffset, fileDescriptor.declaredLength)
-                Interpreter(mapped)
-            }
-        } catch (e: Exception) {
-            null
+    private suspend fun loadModelsIfNeeded() {
+        if (encoder != null && decoder != null) return
+        try {
+            val (encFile, decFile) = ModelFetcher.ensureModels(context)
+            encoder = Interpreter(mapFile(encFile))
+            decoder = Interpreter(mapFile(decFile))
+        } catch (_: Exception) {
+            // leave interpreters null to trigger fallback
+        }
+    }
+
+    private fun mapFile(file: File): MappedByteBuffer {
+        RandomAccessFile(file, "r").use { raf ->
+            return raf.channel.map(FileChannel.MapMode.READ_ONLY, 0, raf.length())
         }
     }
 
     /**
      * Generates a two line summary for the given [text]. Model inference runs on a background
-     * dispatcher. If the bundled models are unavailable, this falls back to a simple extractive
+     * dispatcher. If the models cannot be loaded, this falls back to a simple extractive
      * summary using the first couple of sentences.
      */
     suspend fun summarize(text: String): String = withContext(Dispatchers.Default) {
+        loadModelsIfNeeded()
         if (encoder == null || decoder == null) {
             return@withContext fallbackSummary(text)
         }
@@ -54,3 +60,4 @@ class Summarizer(private val context: Context) {
         return if (candidate.isNotEmpty()) candidate else text.take(200)
     }
 }
+


### PR DESCRIPTION
## Summary
- add `ModelFetcher` that downloads and caches TFLite models from GitHub Releases
- load models on demand in `Summarizer` using `ModelFetcher`
- document automatic model fetching

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c570b2d9a4832084773b762a17c0f4