### PR TITLE
Preserve screen after PIN unlock

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.compose.runtime.*
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.lifecycle.Lifecycle
@@ -46,6 +47,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
     val context = LocalContext.current
     var requireAuth by remember { mutableStateOf(false) }
     var pinCheckEnabled by remember { mutableStateOf(true) }
+    var lastRoute by rememberSaveable { mutableStateOf<String?>(null) }
     val lifecycleOwner = LocalLifecycleOwner.current
 
     DisposableEffect(lifecycleOwner) {
@@ -60,6 +62,12 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
 
     LaunchedEffect(requireAuth) {
         if (requireAuth && navController.currentDestination?.route !in listOf("pin_enter", "pin_setup")) {
+            val entry = navController.currentBackStackEntry
+            lastRoute = entry?.destination?.route?.let { route ->
+                entry.arguments?.keySet()?.fold(route) { acc, key ->
+                    acc.replace("{$key}", entry.arguments?.get(key).toString())
+                }
+            }
             navController.navigate("pin_enter")
         }
     }
@@ -78,13 +86,20 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             PinEnterScreen(pinManager = pinManager) { pin ->
                 requireAuth = false
                 noteViewModel.loadNotes(context, pin)
+                val destination = lastRoute
                 if (navController.previousBackStackEntry != null) {
                     navController.popBackStack()
+                } else if (destination != null) {
+                    navController.navigate(destination) {
+                        popUpTo("pin_enter") { inclusive = true }
+                        launchSingleTop = true
+                    }
                 } else {
                     navController.navigate("list") {
                         popUpTo("pin_enter") { inclusive = true }
                     }
                 }
+                lastRoute = null
             }
         }
         composable("list") {


### PR DESCRIPTION
## Summary
- Save the last navigation route before locking the app and restore it after PIN entry
- Navigate back to the stored destination instead of always returning to the note list

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c573f200c48320aba89e4b8a581622