### PR TITLE
Fix navigation after PIN auth to return to previous screen

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -64,8 +64,13 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         if (requireAuth && navController.currentDestination?.route !in listOf("pin_enter", "pin_setup")) {
             val entry = navController.currentBackStackEntry
             lastRoute = entry?.destination?.route?.let { route ->
-                entry.arguments?.keySet()?.fold(route) { acc, key ->
-                    acc.replace("{$key}", entry.arguments?.get(key).toString())
+                val args = entry.arguments
+                if (args == null) {
+                    route
+                } else {
+                    args.keySet().fold(route) { acc, key ->
+                        acc.replace("{$key}", args.get(key).toString())
+                    }
                 }
             }
             navController.navigate("pin_enter")


### PR DESCRIPTION
## Summary
- retain destination when leaving app so PIN auth returns to the last screen

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c57d220f5c83209c7b681f7efefb40