### PR TITLE
Ensure PIN auth preserves current screen

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -52,7 +52,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_STOP && pinCheckEnabled) {
+            if (event == Lifecycle.Event.ON_PAUSE && pinCheckEnabled) {
                 requireAuth = true
             }
         }


### PR DESCRIPTION
## Summary
- Trigger PIN authentication when the app is paused instead of stopped so the last screen is stored sooner.
- This keeps the user on the New Note screen after returning from background.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c5819914788320a973f063d1dc78b6