### PR TITLE
Update TensorFlow Lite to 2.17.0

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,10 +77,10 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation 'org.tensorflow:tensorflow-lite:2.16.1'
+    implementation 'org.tensorflow:tensorflow-lite:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'org.tensorflow:tensorflow-lite-task-text:0.4.4'
-    implementation 'org.tensorflow:tensorflow-lite-support:0.4.4'
+    implementation 'org.tensorflow:tensorflow-lite-support:0.5.0'
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## Summary
- update TensorFlow Lite dependency to 2.17.0
- bump TensorFlow Lite support library to 0.5.0

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c587b500a883208e0c231ab94baf66