### PR TITLE
Fix TensorFlow Lite dependency conflict

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,10 +77,10 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation 'org.tensorflow:tensorflow-lite:2.17.0'
+    implementation 'org.tensorflow:tensorflow-lite:2.13.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'org.tensorflow:tensorflow-lite-task-text:0.4.4'
-    implementation 'org.tensorflow:tensorflow-lite-support:0.5.0'
+    implementation 'org.tensorflow:tensorflow-lite-support:0.4.4'
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
 
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## Summary
- Align TensorFlow Lite dependencies to 2.13.0 and support library 0.4.4 to avoid duplicate `InterpreterFactory`

## Testing
- `./gradlew build` *(fails: Lint found errors in the project)*
- `./gradlew test -x lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5898060a88320bb7213e8c4c36168