### PR TITLE
Enable core desugaring and update Compose icons

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -56,6 +56,12 @@ android {
         jvmTarget = '1.8'
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+        coreLibraryDesugaringEnabled true
+    }
+
     packaging {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
@@ -82,6 +88,8 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite-task-text:0.4.4'
     implementation 'org.tensorflow:tensorflow-lite-support:0.4.4'
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
+
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'

--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -10,10 +10,10 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.RotateLeft
+import androidx.compose.material.icons.automirrored.filled.RotateLeft
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -61,7 +61,10 @@ fun AddNoteScreen(
                 title = { Text("New Note") },
                 navigationIcon = {
                     IconButton(onClick = onBack) {
-                        Icon(Icons.Filled.ArrowBack, contentDescription = "Back")
+                        Icon(
+                            Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
                     }
                 },
                 actions = {
@@ -117,7 +120,9 @@ fun AddNoteScreen(
                             onValueChange = { newText ->
                                 blocks[index] = block.copy(text = newText)
                             },
-                            label = { if (index == 0) Text("Content") else null },
+                            label = if (index == 0) {
+                                { Text("Content") }
+                            } else null,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = 12.dp)
@@ -143,7 +148,10 @@ fun AddNoteScreen(
                                 },
                                 modifier = Modifier.align(Alignment.BottomStart)
                             ) {
-                                Icon(Icons.Default.RotateLeft, contentDescription = "Rotate")
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.RotateLeft,
+                                        contentDescription = "Rotate"
+                                    )
                             }
                         }
                     }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Image
-import androidx.compose.material.icons.filled.RotateLeft
+import androidx.compose.material.icons.automirrored.filled.RotateLeft
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -192,7 +192,9 @@ fun EditNoteScreen(
                         OutlinedTextField(
                             value = block.text,
                             onValueChange = { newText -> blocks[index] = block.copy(text = newText) },
-                            label = { if (index == 0) Text("Content") else null },
+                            label = if (index == 0) {
+                                { Text("Content") }
+                            } else null,
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .padding(bottom = 12.dp)
@@ -234,7 +236,11 @@ fun EditNoteScreen(
                                     },
                                     modifier = Modifier.align(Alignment.BottomStart)
                                 ) {
-                                    Icon(Icons.Default.RotateLeft, contentDescription = "Rotate", tint = Color.White)
+                                    Icon(
+                                        Icons.AutoMirrored.Filled.RotateLeft,
+                                        contentDescription = "Rotate",
+                                        tint = Color.White
+                                    )
                                 }
                             }
                             IconButton(

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.MoreVert
@@ -42,7 +42,12 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
         TopAppBar(
             title = { Text(note.title) },
             navigationIcon = {
-                IconButton(onClick = onBack) { Icon(Icons.Default.ArrowBack, contentDescription = "Back") }
+                IconButton(onClick = onBack) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = "Back"
+                    )
+                }
             },
             actions = {
                 IconButton(onClick = onEdit) {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.rememberSwipeableState
 import androidx.compose.material.swipeable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
-import androidx.compose.material.icons.filled.NoteAdd
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,7 +47,11 @@ fun NoteListScreen(
                 onClick = onAddNote,
                 backgroundColor = MaterialTheme.colors.primary
             ) {
-                Icon(Icons.Default.NoteAdd, contentDescription = "Add note", tint = Color.White)
+                Icon(
+                    Icons.AutoMirrored.Filled.NoteAdd,
+                    contentDescription = "Add note",
+                    tint = Color.White
+                )
             }
         }
     ) { padding ->


### PR DESCRIPTION
## Summary
- enable core library desugaring for Java 8 APIs
- replace deprecated icons with auto-mirrored versions
- correct composable label lambdas

## Testing
- `./gradlew lintDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c73e57c44c8320b75960025961f11c