### PR TITLE
Use stream-based tokenizer loading for pre-26 compatibility

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
@@ -1,7 +1,7 @@
 package com.example.starbucknotetaker
 
 import ai.djl.sentencepiece.SpTokenizer
-import java.nio.file.Paths
+import java.io.File
 
 /**
  * Wrapper around DJL's SentencePiece tokenizer providing simple encode/decode
@@ -12,7 +12,9 @@ class SentencePieceProcessor {
 
     /** Loads the SentencePiece model from [modelPath]. */
     fun load(modelPath: String) {
-        tokenizer = SpTokenizer(Paths.get(modelPath))
+        File(modelPath).inputStream().use { inputStream ->
+            tokenizer = SpTokenizer(inputStream)
+        }
     }
 
     /** Encodes [text] into an array of token IDs. */


### PR DESCRIPTION
## Summary
- Load SentencePiece model via `File.inputStream()` to avoid `Paths.get` API 26 requirement

## Testing
- ⚠️ `./gradlew :app:lintDebug` *(execution terminated prematurely; verify locally)*

------
https://chatgpt.com/codex/tasks/task_e_68c74862677483208f57609e467ad5ab