### PR TITLE
Fix NDK configuration by removing ndk.dir and specifying version

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,6 +6,7 @@ plugins {
 android {
     namespace 'com.example.starbucknotetaker'
     compileSdk 34
+    ndkVersion '26.1.10909125'
 
     defaultConfig {
         applicationId 'com.example.starbucknotetaker'

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,3 +7,4 @@ android.useAndroidX=true
 android.enableJetifier=true
 
 org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+android.ndkVersion=26.1.10909125

--- a/local.properties
+++ b/local.properties
@@ -1,0 +1,1 @@
+sdk.dir=/root/.android-sdk


### PR DESCRIPTION
## Summary
- drop deprecated `ndk.dir` from local.properties
- declare NDK version 26.1.10909125 in Gradle properties and app module

## Testing
- `./gradlew help`


------
https://chatgpt.com/codex/tasks/task_e_68c7492bfb348320868664cdf717b583