### PR TITLE
Exclude redundant TensorFlow Lite modules

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,10 +83,18 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation 'org.tensorflow:tensorflow-lite:2.13.0'
+    implementation("org.tensorflow:tensorflow-lite:2.13.0") {
+        exclude group: "org.tensorflow", module: "tensorflow-lite-api"
+    }
+    implementation("org.tensorflow:tensorflow-lite-support:0.4.4") {
+        exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
+        exclude group: "org.tensorflow", module: "tensorflow-lite-api"
+    }
+    implementation("org.tensorflow:tensorflow-lite-task-text:0.4.4") {
+        exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
+        exclude group: "org.tensorflow", module: "tensorflow-lite-api"
+    }
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
-    implementation 'org.tensorflow:tensorflow-lite-task-text:0.4.4'
-    implementation 'org.tensorflow:tensorflow-lite-support:0.4.4'
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'


### PR DESCRIPTION
## Summary
- exclude bundled TensorFlow Lite API modules to avoid duplicate classes

## Testing
- No tests were run

------
https://chatgpt.com/codex/tasks/task_e_68c7499c5d708320aed6a810939d086b