### PR TITLE
Add unit tests for summarization

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,12 +54,12 @@ android {
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '11'
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
         coreLibraryDesugaringEnabled true
     }
 
@@ -67,6 +67,10 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+    }
+
+    testOptions {
+        unitTests.includeAndroidResources = true
     }
 }
 
@@ -95,12 +99,17 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
+    implementation 'org.tensorflow:tensorflow-lite-api:2.13.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation 'org.mockito:mockito-core:5.2.0'
+    testImplementation 'org.mockito:mockito-inline:5.2.0'
+    testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
+    testImplementation 'org.tensorflow:tensorflow-lite-api:2.13.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation platform('androidx.compose:compose-bom:2024.06.00')

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -1,0 +1,75 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.Tensor
+
+class SummarizerTest {
+    private val context: Context = mock()
+
+    @Test
+    fun fallbackSummaryReturnsFirstTwoSentences() {
+        val summarizer = Summarizer(context)
+        val text = "Sentence one. Sentence two. Sentence three."
+        val summary = summarizer.fallbackSummary(text)
+        assertEquals("Sentence one. Sentence two", summary)
+    }
+
+    @Test
+    fun summarizeUsesModelWhenAvailable() = runBlocking {
+        val summarizer = Summarizer(context)
+
+        val encoder = mock<Interpreter>()
+        val decoder = mock<Interpreter>()
+        val tokenizer = mock<SentencePieceProcessor>()
+        val tensor = mock<Tensor>()
+
+        whenever(tokenizer.encodeAsIds(any())).thenReturn(intArrayOf(5, 6, 7))
+        whenever(tokenizer.decodeIds(any())).thenReturn("mock summary")
+
+        whenever(encoder.getOutputTensor(0)).thenReturn(tensor)
+        whenever(tensor.shape()).thenReturn(intArrayOf(1, 1, 1))
+        doAnswer { }.whenever(encoder).run(any(), any())
+
+        whenever(decoder.inputTensorCount).thenReturn(4)
+        val inTensor = mock<Tensor>()
+        whenever(decoder.getInputTensor(3)).thenReturn(inTensor)
+        whenever(inTensor.numElements()).thenReturn(1)
+        val outTensor = mock<Tensor>()
+        whenever(decoder.getOutputTensor(1)).thenReturn(outTensor)
+        whenever(outTensor.numElements()).thenReturn(1)
+
+        var calls = 0
+        doAnswer {
+            val outputs = it.arguments[1] as MutableMap<Int, Any>
+            val logits = outputs[0] as FloatArray
+            if (calls == 0) {
+                logits[123] = 1f
+            } else {
+                logits[1] = 1f
+            }
+            calls++
+            null
+        }.whenever(decoder).runForMultipleInputsOutputs(any(), any())
+
+        setField(summarizer, "encoder", encoder)
+        setField(summarizer, "decoder", decoder)
+        setField(summarizer, "tokenizer", tokenizer)
+
+        val result = summarizer.summarize("input text")
+        assertEquals("mock summary", result)
+    }
+
+    private fun setField(target: Any, fieldName: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+}


### PR DESCRIPTION
## Summary
- configure project for Java 11 and add missing TensorFlow Lite API dependency
- add Mockito-based unit tests covering summarizer fallback and model paths

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c74d2d0fc883209512d75c9afdab02