### PR TITLE
Release summarizer resources when ViewModel is cleared

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -133,6 +133,11 @@ class NoteViewModel : ViewModel() {
             }
         }
     }
+
+    override fun onCleared() {
+        summarizer?.close()
+        super.onCleared()
+    }
     private fun isImageUrl(url: String): Boolean {
         val lower = url.lowercase()
         return Patterns.WEB_URL.matcher(url).matches() &&

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -107,6 +107,16 @@ class Summarizer(private val context: Context) {
         return if (candidate.isNotEmpty()) candidate else text.take(200)
     }
 
+    /** Releases model and tokenizer resources. */
+    fun close() {
+        encoder?.close()
+        decoder?.close()
+        tokenizer?.close()
+        encoder = null
+        decoder = null
+        tokenizer = null
+    }
+
     private fun argmax(arr: FloatArray): Int {
         var maxIdx = 0
         var maxVal = arr[0]


### PR DESCRIPTION
## Summary
- Add `close()` to `Summarizer` to free interpreter and tokenizer resources
- Invoke `Summarizer.close()` in `NoteViewModel.onCleared()` to release resources when ViewModel is disposed

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c74fe0e2988320ae6cb891cf753043