### PR TITLE
Add NoteViewModel summary update unit test

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -109,6 +109,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
+    testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'org.tensorflow:tensorflow-lite-api:2.13.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -1,0 +1,53 @@
+package com.example.starbucknotetaker
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.junit.Assert.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NoteViewModelTest {
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun addNoteUpdatesSummaryFromSummarizer() = runTest(dispatcher.scheduler) {
+        val summarizer = mock<Summarizer>()
+        whenever(summarizer.fallbackSummary(any())).thenReturn("initial summary")
+        whenever(summarizer.summarize(any())).thenReturn("mocked summary")
+
+        val viewModel = NoteViewModel()
+        setField(viewModel, "summarizer", summarizer)
+
+        viewModel.addNote("Title", "Content", emptyList())
+
+        advanceUntilIdle()
+
+        assertEquals("mocked summary", viewModel.notes[0].summary)
+    }
+
+    private fun setField(target: Any, name: String, value: Any?) {
+        val field = target.javaClass.getDeclaredField(name)
+        field.isAccessible = true
+        field.set(target, value)
+    }
+}


### PR DESCRIPTION
## Summary
- add coroutine test dependency
- verify NoteViewModel replaces note summary with mocked Summarizer result

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c750af46788320a7ee7c21d4e4c722