### PR TITLE
Use new host for summarizer model downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ This repository uses the included Gradle wrapper. Typical commands:
 
 ## On-device summarization models
 
-The app downloads its TensorFlow Lite summarisation models from the project's
-GitHub Releases on first run and caches them under internal storage. If the
-download fails, summaries gracefully fall back to a simple extractive method.
+The app downloads its TensorFlow Lite summarisation models from a public
+endpoint at `https://music.corsicanescape.com/apk/` on first run and caches
+them under internal storage. If the download fails, summaries gracefully fall
+back to a simple extractive method.
 
-The release asset URL and optional SHA-256 checksum are configured in
-`ModelFetcher`. Update these constants when publishing new model versions.
+The model URLs are configured in `ModelFetcher`. Update these constants when
+publishing new model versions or moving the files.
 
 ## Requirements
 

--- a/app/src/main/java/com/example/starbucknotetaker/ModelFetcher.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ModelFetcher.kt
@@ -10,11 +10,11 @@ import java.io.FileOutputStream
 import java.security.MessageDigest
 
 /**
- * Downloads the summarization models from GitHub Releases on first run.
+ * Downloads the summarization models from a public endpoint on first run.
  * The models are stored under `files/models` in the app's internal storage.
  */
 object ModelFetcher {
-    private const val BASE_URL = "https://github.com/nickprice101/StarbuckNoteTaker/releases/download/v1.0.0/"
+    private const val BASE_URL = "https://music.corsicanescape.com/apk/"
 
     private const val ENCODER_REMOTE = "encoder_int8_dynamic.tflite"
     private const val DECODER_REMOTE = "decoder_step_int8_dynamic.tflite"


### PR DESCRIPTION
## Summary
- point `ModelFetcher` at the new public model host
- document model hosting change in README

## Testing
- `./gradlew test`
- `curl -I https://music.corsicanescape.com/apk/encoder_int8_dynamic.tflite`
- `curl -I https://music.corsicanescape.com/apk/decoder_step_int8_dynamic.tflite`
- `curl -I https://music.corsicanescape.com/apk/spiece.model`


------
https://chatgpt.com/codex/tasks/task_e_68c74f392b588320b959258e045edbd8