### PR TITLE
Update TensorFlow Lite version to handle newer ops

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -88,7 +88,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation("org.tensorflow:tensorflow-lite:2.13.0") {
+    implementation("org.tensorflow:tensorflow-lite:2.15.0") {
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
     implementation("org.tensorflow:tensorflow-lite-support:0.4.4") {
@@ -99,7 +99,7 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
-    implementation 'org.tensorflow:tensorflow-lite-api:2.13.0'
+    implementation 'org.tensorflow:tensorflow-lite-api:2.15.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
 
@@ -110,7 +110,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-    testImplementation 'org.tensorflow:tensorflow-lite-api:2.13.0'
+    testImplementation 'org.tensorflow:tensorflow-lite-api:2.15.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation platform('androidx.compose:compose-bom:2024.06.00')


### PR DESCRIPTION
## Summary
- bump TensorFlow Lite runtime and API dependencies to 2.15.0

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c75616f4408320a8539b03838c53dc