### PR TITLE
chore: increase min sdk to 26

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,7 +10,7 @@ android {
 
     defaultConfig {
         applicationId 'com.example.starbucknotetaker'
-        minSdk 24
+        minSdk 26
         targetSdk 34
         versionCode System.getenv("ANDROID_VERSION_CODE")?.toInteger() ?: 1
         versionName System.getenv("ANDROID_VERSION_NAME") ?: '1.0'


### PR DESCRIPTION
## Summary
- bump minSdk to 26 to satisfy Guice dependency requirements

## Testing
- `./gradlew build` (fails: SummarizerTest.summarizeDownloadsAndUsesLatestModels)


------
https://chatgpt.com/codex/tasks/task_e_68c7c49f85208320abd163d62d6b0c4d