### PR TITLE
Add file attachment support

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,6 +18,15 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -34,6 +34,18 @@ class EncryptedNoteStore(private val context: Context) {
             for (j in 0 until imagesJson.length()) {
                 images.add(imagesJson.getString(j))
             }
+            val filesJson = obj.optJSONArray("files") ?: JSONArray()
+            val files = mutableListOf<NoteFile>()
+            for (j in 0 until filesJson.length()) {
+                val f = filesJson.getJSONObject(j)
+                files.add(
+                    NoteFile(
+                        name = f.getString("name"),
+                        mime = f.getString("mime"),
+                        data = f.getString("data"),
+                    )
+                )
+            }
             notes.add(
                 Note(
                     id = obj.getLong("id"),
@@ -41,6 +53,7 @@ class EncryptedNoteStore(private val context: Context) {
                     content = obj.getString("content"),
                     date = obj.getLong("date"),
                     images = images,
+                    files = files,
                     summary = obj.optString("summary", "")
                 )
             )
@@ -59,6 +72,15 @@ class EncryptedNoteStore(private val context: Context) {
             val imagesArray = JSONArray()
             note.images.forEach { imagesArray.put(it) }
             obj.put("images", imagesArray)
+            val filesArray = JSONArray()
+            note.files.forEach { f ->
+                val fo = JSONObject()
+                fo.put("name", f.name)
+                fo.put("mime", f.mime)
+                fo.put("data", f.data)
+                filesArray.put(fo)
+            }
+            obj.put("files", filesArray)
             obj.put("summary", note.summary)
             arr.put(obj)
         }

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -117,8 +117,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         }
         composable("add") {
             AddNoteScreen(
-                onSave = { title, content, images ->
-                    noteViewModel.addNote(title, content, images)
+                onSave = { title, content, images, files ->
+                    noteViewModel.addNote(title, content, images, files)
                     navController.popBackStack()
                 },
                 onBack = { navController.popBackStack() },
@@ -143,8 +143,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             if (note != null) {
                 EditNoteScreen(
                     note = note,
-                    onSave = { title, content, images ->
-                        noteViewModel.updateNote(index, title, content, images)
+                    onSave = { title, content, images, files ->
+                        noteViewModel.updateNote(index, title, content, images, files)
                         navController.popBackStack()
                     },
                     onCancel = { navController.popBackStack() },

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -1,7 +1,7 @@
 package com.example.starbucknotetaker
 
 /**
- * Represents a note with title, textual content, creation date and optional images.
+ * Represents a note with title, textual content, creation date and optional attachments.
  */
 data class Note(
     val id: Long = System.currentTimeMillis(),
@@ -9,5 +9,18 @@ data class Note(
     val content: String,
     val date: Long = System.currentTimeMillis(),
     val images: List<String> = emptyList(),
-    val summary: String = ""
+    val files: List<NoteFile> = emptyList(),
+    val summary: String = "",
 )
+
+/**
+ * Represents an arbitrary file embedded within a note. The file is stored as
+ * a base64 string along with its original name and MIME type so it can be
+ * reconstructed and opened later.
+ */
+data class NoteFile(
+    val name: String,
+    val mime: String,
+    val data: String,
+)
+

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <cache-path name="files" path="." />
+</paths>

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -38,7 +38,7 @@ class NoteViewModelTest {
         val viewModel = NoteViewModel()
         setField(viewModel, "summarizer", summarizer)
 
-        viewModel.addNote("Title", "Content", emptyList())
+        viewModel.addNote("Title", "Content", emptyList(), emptyList())
 
         advanceUntilIdle()
 


### PR DESCRIPTION
## Summary
- allow attaching arbitrary files to notes via new Add File menu
- embed file data and persist it securely alongside images
- show file icons in notes and open attachments with appropriate apps

## Testing
- `./gradlew test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c5dba1bc8320bbe3c10621adeb82