### PR TITLE
Add settings page with import/export actions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     package="com.example.starbucknotetaker">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -17,6 +17,10 @@ class EncryptedNoteStore(private val context: Context) {
     fun loadNotes(pin: String): List<Note> {
         if (!file.exists()) return emptyList()
         val bytes = file.readBytes()
+        return loadNotesFromBytes(bytes, pin)
+    }
+
+    fun loadNotesFromBytes(bytes: ByteArray, pin: String): List<Note> {
         if (bytes.size < 28) return emptyList()
         val salt = bytes.copyOfRange(0, 16)
         val iv = bytes.copyOfRange(16, 28)

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -22,6 +22,7 @@ import com.example.starbucknotetaker.ui.PinEnterScreen
 import com.example.starbucknotetaker.ui.PinSetupScreen
 import com.example.starbucknotetaker.ui.EditNoteScreen
 import com.example.starbucknotetaker.ui.StarbuckNoteTakerTheme
+import com.example.starbucknotetaker.ui.SettingsScreen
 
 class MainActivity : ComponentActivity() {
     private val noteViewModel: NoteViewModel by viewModels()
@@ -112,7 +113,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 notes = noteViewModel.notes,
                 onAddNote = { navController.navigate("add") },
                 onOpenNote = { index -> navController.navigate("detail/$index") },
-                onDeleteNote = { index -> noteViewModel.deleteNote(index) }
+                onDeleteNote = { index -> noteViewModel.deleteNote(index) },
+                onSettings = { navController.navigate("settings") }
             )
         }
         composable("add") {
@@ -152,6 +154,13 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                     onEnablePinCheck = { pinCheckEnabled = true }
                 )
             }
+        }
+        composable("settings") {
+            SettingsScreen(
+                onBack = { navController.popBackStack() },
+                onImport = { uri, pin, overwrite -> noteViewModel.importNotes(context, uri, pin, overwrite) },
+                onExport = { noteViewModel.exportNotes(context) }
+            )
         }
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -10,6 +10,8 @@ import android.graphics.Matrix
 import androidx.exifinterface.media.ExifInterface
 import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
+import java.io.File
+import android.os.Environment
 import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -132,6 +134,32 @@ class NoteViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    fun exportNotes(context: Context) {
+        val currentPin = pin ?: return
+        store?.saveNotes(_notes, currentPin)
+        val src = File(context.filesDir, "notes.enc")
+        val downloads = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+        if (!downloads.exists()) downloads.mkdirs()
+        val dest = File(downloads, "notes.snarchive")
+        try {
+            src.copyTo(dest, overwrite = true)
+        } catch (_: Exception) {}
+    }
+
+    fun importNotes(context: Context, uri: Uri, archivePin: String, overwrite: Boolean) {
+        try {
+            context.contentResolver.openInputStream(uri)?.use { input ->
+                val bytes = input.readBytes()
+                val imported = EncryptedNoteStore(context).loadNotesFromBytes(bytes, archivePin)
+                if (overwrite) {
+                    _notes.clear()
+                }
+                _notes.addAll(imported)
+                pin?.let { store?.saveNotes(_notes, it) }
+            }
+        } catch (_: Exception) {}
     }
 
     override fun onCleared() {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.rememberSwipeableState
 import androidx.compose.material.swipeable
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -32,7 +33,8 @@ fun NoteListScreen(
     notes: List<Note>,
     onAddNote: () -> Unit,
     onOpenNote: (Int) -> Unit,
-    onDeleteNote: (Int) -> Unit
+    onDeleteNote: (Int) -> Unit,
+    onSettings: () -> Unit
 ) {
     var query by remember { mutableStateOf("") }
     val filtered = notes.filter {
@@ -43,15 +45,29 @@ fun NoteListScreen(
     var openIndex by remember { mutableStateOf<Int?>(null) }
     Scaffold(
         floatingActionButton = {
-            FloatingActionButton(
-                onClick = onAddNote,
-                backgroundColor = MaterialTheme.colors.primary
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
-                Icon(
-                    Icons.AutoMirrored.Filled.NoteAdd,
-                    contentDescription = "Add note",
-                    tint = Color.White
-                )
+                FloatingActionButton(
+                    onClick = onSettings,
+                    backgroundColor = MaterialTheme.colors.primary
+                ) {
+                    Icon(
+                        Icons.Default.Settings,
+                        contentDescription = "Settings",
+                        tint = Color.White
+                    )
+                }
+                FloatingActionButton(
+                    onClick = onAddNote,
+                    backgroundColor = MaterialTheme.colors.primary
+                ) {
+                    Icon(
+                        Icons.AutoMirrored.Filled.NoteAdd,
+                        contentDescription = "Add note",
+                        tint = Color.White
+                    )
+                }
             }
         }
     ) { padding ->


### PR DESCRIPTION
## Summary
- add settings gear button next to add note
- create settings screen with import/export archive controls
- implement import/export logic for notes archive

## Testing
- `./gradlew test` *(fails: java.net.SocketException in SummarizerTest)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c8ffa9d483209abf3642d2a43f00