### PR TITLE
Refactor ModelFetcher for configurable base URL

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -112,6 +112,7 @@ dependencies {
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
     testImplementation 'org.tensorflow:tensorflow-lite-api:2.15.0'
     testImplementation 'org.json:json:20240303'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation platform('androidx.compose:compose-bom:2024.06.00')

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -21,7 +21,10 @@ import java.nio.channels.FileChannel
  * greedy sequence-to-sequence inference. If anything fails it falls back to a
  * lightweight extractive strategy.
  */
-class Summarizer(private val context: Context) {
+class Summarizer(
+    private val context: Context,
+    private val fetcher: ModelFetcher = ModelFetcher()
+) {
     private var encoder: Interpreter? = null
     private var decoder: Interpreter? = null
     private var tokenizer: SentencePieceProcessor? = null
@@ -29,7 +32,7 @@ class Summarizer(private val context: Context) {
     private suspend fun loadModelsIfNeeded() {
         if (encoder != null && decoder != null && tokenizer != null) return
         try {
-            val (encFile, decFile, spFile) = ModelFetcher.ensureModels(context)
+            val (encFile, decFile, spFile) = fetcher.ensureModels(context)
             encoder = Interpreter(mapFile(encFile))
             decoder = Interpreter(mapFile(decFile))
             tokenizer = SentencePieceProcessor().apply { load(spFile.absolutePath) }


### PR DESCRIPTION
## Summary
- Refactor ModelFetcher into a class that accepts a base URL and OkHttpClient, enabling injection for testing while keeping production defaults.
- Inject ModelFetcher into Summarizer and update usage accordingly.
- Rewrite SummarizerTest to use MockWebServer with tiny dummy model files, verifying downloads and summary generation.
- Add mockwebserver test dependency.

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c7cf9e03248320b65d629af45de35c