### PR TITLE
Remove ndk.dir usage in setup

### DIFF
--- a/setup_persist.sh
+++ b/setup_persist.sh
@@ -47,10 +47,9 @@ sdkmanager --install \
 ANDROID_NDK_ROOT="$ANDROID_SDK_ROOT/ndk/26.1.10909125"
 export ANDROID_NDK_ROOT ANDROID_NDK_HOME="$ANDROID_NDK_ROOT"
 
-echo "📄 Writing local.properties with SDK and NDK paths..."
+echo "📄 Writing local.properties with SDK path..."
 cat <<EOF > "$PROJECT_DIR/local.properties"
 sdk.dir=$ANDROID_SDK_ROOT
-ndk.dir=$ANDROID_NDK_ROOT
 EOF
 
 # ----------------------------


### PR DESCRIPTION
## Summary
- Avoid writing deprecated `ndk.dir` to `local.properties`
- Rely on `android.ndkVersion` for NDK configuration

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c7d95a0c0c8320a2bb747cfda5b8f7