### PR TITLE
Fix summarizer native dependency and fallback handling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -67,6 +67,9 @@ android {
         resources {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
+        jniLibs {
+            useLegacyPackaging true
+        }
     }
 
     testOptions {
@@ -102,6 +105,7 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
+    runtimeOnly 'ai.djl.android:tokenizer-native:0.33.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 


### PR DESCRIPTION
## Summary
- include DJL tokenizer native runtime for Android and keep JNI libs packaged
- make summarizer catch native loading errors and allow injecting tokenizer factory
- test summarizer fallback when native tokenizer is unavailable

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c7f1d690dc8320aa00515085d6bcc7