### PR TITLE
Expose summarizer state via flow and observe in view model

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -114,7 +114,7 @@ class SummarizerTest {
         val tokenizer = mock<SentencePieceProcessor>()
         whenever(tokenizer.load(any())).thenThrow(UnsatisfiedLinkError("missing lib"))
 
-        val summarizer = Summarizer(context, fetcher, spFactory = { tokenizer }, toast = { _, _ -> }, logger = { _, _ -> })
+        val summarizer = Summarizer(context, fetcher, spFactory = { tokenizer }, logger = { _, _ -> })
 
         val text = "One. Two. Three."
         val result = summarizer.summarize(text)


### PR DESCRIPTION
## Summary
- Replace toast-based updates in `Summarizer` with a `MutableStateFlow` of `SummarizerState` and emit loading, ready, fallback, and error states.
- Modify `NoteViewModel` to collect summarizer states, show appropriate messages, and expose the state for UI observation.
- Adjust tests for new `Summarizer` API.

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c7fab2a0648320b1ff8aee11290e5e