### PR TITLE
Handle model download failures with result types

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -50,7 +50,8 @@ class SummarizerTest {
         val client = OkHttpClient()
         val fetcher = ModelFetcher(server.url("/").toString(), client)
 
-        fetcher.ensureModels(context)
+        val fetchResult = fetcher.ensureModels(context)
+        assertTrue(fetchResult is ModelFetcher.Result.Success)
 
         val savedDir = File(modelsDir, "models")
         assertTrue(File(savedDir, ModelFetcher.ENCODER_NAME).exists())
@@ -96,8 +97,8 @@ class SummarizerTest {
         setField(summarizer, "decoder", decoder)
         setField(summarizer, "tokenizer", tokenizer)
 
-        val result = summarizer.summarize("input text")
-        assertEquals("mock summary", result)
+        val summary = summarizer.summarize("input text")
+        assertEquals("mock summary", summary)
         server.shutdown()
     }
 
@@ -109,7 +110,9 @@ class SummarizerTest {
         val spFile = File(modelsDir, ModelFetcher.SPIECE_NAME).apply { writeBytes(byteArrayOf()) }
 
         val fetcher = mock<ModelFetcher>()
-        whenever(fetcher.ensureModels(any())).thenReturn(Triple(encFile, decFile, spFile))
+        whenever(fetcher.ensureModels(any())).thenReturn(
+            ModelFetcher.Result.Success(encFile, decFile, spFile)
+        )
 
         val tokenizer = mock<SentencePieceProcessor>()
         whenever(tokenizer.load(any())).thenThrow(UnsatisfiedLinkError("missing lib"))


### PR DESCRIPTION
## Summary
- Return a sealed `Result` from `ModelFetcher.ensureModels` to capture success or failure
- Update `Summarizer` to react to fetch failures and emit error state instead of throwing
- Adjust tests for the new result API

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c7fc07a29c8320bc5a381e83a5a55f