### PR TITLE
Add missing data sync foreground service permission

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,8 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+    <!-- Required for starting WorkManager foreground services on Android 14+ -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application


### PR DESCRIPTION
## Summary
- allow WorkManager foreground service startup on Android 14 by requesting `FOREGROUND_SERVICE_DATA_SYNC`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c821ccf9f88320ae2a7b0780c3c995