### PR TITLE
Declare foreground service type for WorkManager

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="com.example.starbucknotetaker">
 
     <uses-permission android:name="android.permission.INTERNET"/>
@@ -33,6 +34,13 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+        <!-- Make WorkManager's foreground service type explicit for Android 14+ -->
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            android:exported="false"
+            tools:node="merge" />
     </application>
 
 </manifest>


### PR DESCRIPTION
## Summary
- allow WorkManager to start a foreground service on Android 14+ by specifying the SystemForegroundService type
- enable manifest merging with the tools namespace

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c8291d2dc08320890a70d68eb0027c