### PR TITLE
Fix Android 14 runtime issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
     implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
-    runtimeOnly 'ai.djl.android:tokenizer-native:0.33.0'
+    implementation 'ai.djl.android:tokenizer-native:0.33.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:hardwareAccelerated="false"
+        android:hardwareAccelerated="true"
         android:theme="@style/Theme.StarbuckNoteTaker">
         <activity
             android:name=".MainActivity"

--- a/app/src/main/java/com/example/starbucknotetaker/ModelDownloadWorker.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ModelDownloadWorker.kt
@@ -9,6 +9,7 @@ import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
 import androidx.work.ForegroundInfo
 import androidx.work.WorkerParameters
+import android.content.pm.ServiceInfo
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
@@ -89,6 +90,14 @@ class ModelDownloadWorker(
             .setProgress(100, progress, false)
             .build()
 
-        return ForegroundInfo(42, notification)
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                42,
+                notification,
+                ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+            )
+        } else {
+            ForegroundInfo(42, notification)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- specify foreground service type for model downloads on Android 14+
- bundle native tokenizer library so SentencePiece loads correctly
- enable hardware acceleration to avoid hidden API calls

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c836725fd0832083beed8b4959d25d