### PR TITLE
Implement QSPM service integration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,7 @@ android {
 
     buildFeatures {
         compose true
+        aidl true
     }
 
     composeOptions {

--- a/app/src/main/aidl/com/example/starbucknotetaker/IQspmService.aidl
+++ b/app/src/main/aidl/com/example/starbucknotetaker/IQspmService.aidl
@@ -1,0 +1,21 @@
+package com.example.starbucknotetaker;
+
+import com.example.starbucknotetaker.IQspmSummaryCallback;
+
+interface IQspmService {
+    const int STATE_READY = 0;
+    const int STATE_LOADING = 1;
+    const int STATE_FALLBACK = 2;
+    const int STATE_ERROR = 3;
+
+    boolean isPinSet();
+    int getPinLength();
+    boolean verifyPin(String pin);
+    boolean storePin(String pin);
+    boolean updatePin(String oldPin, String newPin);
+    void clearPin();
+
+    int getSummarizerState();
+    int warmUpSummarizer();
+    void summarize(String text, IQspmSummaryCallback callback);
+}

--- a/app/src/main/aidl/com/example/starbucknotetaker/IQspmSummaryCallback.aidl
+++ b/app/src/main/aidl/com/example/starbucknotetaker/IQspmSummaryCallback.aidl
@@ -1,0 +1,9 @@
+package com.example.starbucknotetaker;
+
+interface IQspmSummaryCallback {
+    /** Called when summarization completed. */
+    void onComplete(String summary, boolean usedFallback);
+
+    /** Called if summarization fails before producing output. */
+    void onError(String message);
+}

--- a/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
@@ -15,4 +15,18 @@ class PinManager(context: Context) {
     fun checkPin(pin: String): Boolean = prefs.getString("pin", null) == pin
 
     fun getPinLength(): Int = prefs.getString("pin", null)?.length ?: 0
+
+    fun updatePin(oldPin: String, newPin: String): Boolean {
+        val stored = prefs.getString("pin", null) ?: return false
+        return if (stored == oldPin) {
+            prefs.edit().putString("pin", newPin).apply()
+            true
+        } else {
+            false
+        }
+    }
+
+    fun clearPin() {
+        prefs.edit().remove("pin").apply()
+    }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/QspmService.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/QspmService.kt
@@ -2,19 +2,164 @@ package com.example.starbucknotetaker
 
 import android.app.Service
 import android.content.Intent
-import android.os.Binder
 import android.os.IBinder
+import android.os.RemoteException
 import android.util.Log
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import java.util.concurrent.atomic.AtomicReference
 
 /**
- * Minimal stub implementation of the QSPM AIDL service. Some devices look up
- * this service by name; providing a no-op implementation prevents binder lookup
- * failures while keeping the functionality optional for the app.
+ * Implementation of the QSPM AIDL service.
+ *
+ * The service bridges binder clients to local application facilities:
+ *  - PIN management is handled through [PinManager]
+ *  - Summarization requests are delegated to the on-device [Summarizer]
+ *
+ * Operations run on a background [CoroutineScope] so callers never block the
+ * binder thread. Results are dispatched via the generated AIDL stubs.
  */
 class QspmService : Service() {
+
+    private val serviceScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val pinManager by lazy { PinManager(applicationContext) }
+    private val summarizerRef = AtomicReference<Summarizer?>()
+
+    @Volatile
+    private var warmUpJob: Job? = null
+
+    private val binder = object : IQspmService.Stub() {
+        override fun isPinSet(): Boolean = pinManager.isPinSet()
+
+        override fun getPinLength(): Int = pinManager.getPinLength()
+
+        override fun verifyPin(pin: String?): Boolean = pin?.let { pinManager.checkPin(it) } ?: false
+
+        override fun storePin(pin: String?): Boolean {
+            val candidate = pin?.trim() ?: return false
+            if (!isValidPin(candidate) || pinManager.isPinSet()) {
+                return false
+            }
+            pinManager.setPin(candidate)
+            return true
+        }
+
+        override fun updatePin(oldPin: String?, newPin: String?): Boolean {
+            val newCandidate = newPin?.trim() ?: return false
+            if (!isValidPin(newCandidate)) return false
+            val current = pinManager.isPinSet()
+            return if (!current) {
+                pinManager.setPin(newCandidate)
+                true
+            } else {
+                val oldCandidate = oldPin ?: return false
+                pinManager.updatePin(oldCandidate, newCandidate)
+            }
+        }
+
+        override fun clearPin() {
+            pinManager.clearPin()
+        }
+
+        override fun getSummarizerState(): Int = mapState(obtainSummarizer().state.value)
+
+        override fun warmUpSummarizer(): Int {
+            val summarizer = obtainSummarizer()
+            val current = summarizer.state.value
+            if (current is Summarizer.SummarizerState.Ready) {
+                return IQspmService.STATE_READY
+            }
+            if (warmUpJob?.isActive != true) {
+                warmUpJob = serviceScope.launch {
+                    try {
+                        summarizer.warmUp()
+                    } catch (t: Throwable) {
+                        Log.e(TAG, "Failed to warm up summarizer", t)
+                    } finally {
+                        warmUpJob = null
+                    }
+                }
+            }
+            return mapState(summarizer.state.value)
+        }
+
+        override fun summarize(text: String?, callback: IQspmSummaryCallback?) {
+            if (callback == null) {
+                Log.w(TAG, "summarize called without callback")
+                return
+            }
+            val input = text?.takeIf { it.isNotBlank() }
+            if (input == null) {
+                deliverError(callback, "Text must not be empty")
+                return
+            }
+            val summarizer = obtainSummarizer()
+            serviceScope.launch {
+                try {
+                    val summary = summarizer.summarize(input)
+                    val fallback = summarizer.state.value is Summarizer.SummarizerState.Fallback
+                    deliverSuccess(callback, summary, fallback)
+                } catch (t: Throwable) {
+                    Log.e(TAG, "Summarization failed", t)
+                    deliverError(callback, t.message ?: "Failed to summarize text")
+                }
+            }
+        }
+    }
+
     override fun onBind(intent: Intent?): IBinder {
-        Log.d("QspmService", "Stub QSPM service bound")
-        return Binder()
+        Log.d(TAG, "QSPM binder connection established")
+        return binder
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        warmUpJob?.cancel()
+        serviceScope.cancel()
+        summarizerRef.getAndSet(null)?.close()
+    }
+
+    private fun obtainSummarizer(): Summarizer {
+        while (true) {
+            summarizerRef.get()?.let { return it }
+            val created = Summarizer(applicationContext)
+            if (summarizerRef.compareAndSet(null, created)) {
+                return created
+            }
+            created.close()
+        }
+    }
+
+    private fun isValidPin(pin: String): Boolean = pin.length in 4..6 && pin.all { it.isDigit() }
+
+    private fun mapState(state: Summarizer.SummarizerState): Int = when (state) {
+        Summarizer.SummarizerState.Ready -> IQspmService.STATE_READY
+        Summarizer.SummarizerState.Loading -> IQspmService.STATE_LOADING
+        Summarizer.SummarizerState.Fallback -> IQspmService.STATE_FALLBACK
+        is Summarizer.SummarizerState.Error -> IQspmService.STATE_ERROR
+    }
+
+    private fun deliverError(callback: IQspmSummaryCallback, message: String) {
+        try {
+            callback.onError(message)
+        } catch (e: RemoteException) {
+            Log.w(TAG, "Failed to deliver summary error", e)
+        }
+    }
+
+    private fun deliverSuccess(callback: IQspmSummaryCallback, summary: String, fallback: Boolean) {
+        try {
+            callback.onComplete(summary, fallback)
+        } catch (e: RemoteException) {
+            Log.w(TAG, "Failed to deliver summary result", e)
+        }
+    }
+
+    companion object {
+        private const val TAG = "QspmService"
     }
 }
-

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -103,6 +103,16 @@ class Summarizer(
     }
 
     /**
+     * Ensures the TensorFlow models and tokenizer are ready for inference.
+     * Returns the resulting [SummarizerState] so callers can react to fallbacks
+     * or failures when using the service through IPC.
+     */
+    suspend fun warmUp(): SummarizerState = withContext(Dispatchers.Default) {
+        loadModelsIfNeeded()
+        state.value
+    }
+
+    /**
      * Generates a summary for the given [text]. Model inference runs on a background
      * dispatcher. If the models cannot be loaded, this falls back to a simple extractive
      * summary using the first couple of sentences.

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -55,6 +55,23 @@ class SummarizerTest {
         assertEquals("One. Two", result)
     }
 
+    @Test
+    fun warmUpReportsFallbackWhenNativeTokenizerMissing() = runBlocking {
+        val encFile = File(modelsDir, ModelFetcher.ENCODER_NAME).apply { writeBytes(byteArrayOf()) }
+        val decFile = File(modelsDir, ModelFetcher.DECODER_NAME).apply { writeBytes(byteArrayOf()) }
+        val spFile = File(modelsDir, ModelFetcher.SPIECE_NAME).apply { writeBytes(byteArrayOf()) }
+
+        val fetcher = mock<ModelFetcher>()
+        whenever(fetcher.ensureModels(any())).thenReturn(
+            ModelFetcher.Result.Success(encFile, decFile, spFile)
+        )
+
+        val summarizer = Summarizer(context, fetcher, logger = { _, _ -> }, debug = { })
+
+        val state = summarizer.warmUp()
+        assertEquals(Summarizer.SummarizerState.Fallback, state)
+    }
+
     private fun setField(target: Any, fieldName: String, value: Any?) {
         val field = target.javaClass.getDeclaredField(fieldName)
         field.isAccessible = true


### PR DESCRIPTION
## Summary
- add AIDL definitions and fully implement the QSPM binder service to manage PIN data and dispatch summarization requests
- extend PinManager and Summarizer to support the service, including a warm-up routine with test coverage
- enable AIDL code generation in Gradle so the new interfaces compile

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68c9466479d483209a58aef7779b282f