### PR TITLE
Clear focus when leaving text screens

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
 
@@ -35,6 +36,7 @@ fun AddNoteScreen(
     val blocks = remember { mutableStateListOf<NoteBlock>(NoteBlock.Text("")) }
     val context = LocalContext.current
     val hideKeyboard = rememberKeyboardHider()
+    val focusManager = LocalFocusManager.current
 
     val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
         uri?.let {
@@ -75,6 +77,7 @@ fun AddNoteScreen(
     DisposableEffect(Unit) {
         onDispose {
             hideKeyboard()
+            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import androidx.exifinterface.media.ExifInterface
 import com.example.starbucknotetaker.Note
@@ -86,6 +87,7 @@ fun EditNoteScreen(
     val scaffoldState = rememberScaffoldState()
     val scope = rememberCoroutineScope()
     val hideKeyboard = rememberKeyboardHider()
+    val focusManager = LocalFocusManager.current
 
     val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
         onEnablePinCheck()
@@ -166,6 +168,7 @@ fun EditNoteScreen(
     DisposableEffect(Unit) {
         onDispose {
             hideKeyboard()
+            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
@@ -43,6 +44,11 @@ fun NoteListScreen(
                 it.summary.contains(query, true)
     }
     var openIndex by remember { mutableStateOf<Int?>(null) }
+    val focusManager = LocalFocusManager.current
+
+    DisposableEffect(Unit) {
+        onDispose { focusManager.clearFocus(force = true) }
+    }
     Scaffold(
         floatingActionButton = {
             Row(

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
@@ -43,6 +44,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
     var reveal by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
     val hideKeyboard = rememberKeyboardHider()
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(pin) {
         if (reveal) {
@@ -53,7 +55,10 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     DisposableEffect(Unit) {
-        onDispose { hideKeyboard() }
+        onDispose {
+            hideKeyboard()
+            focusManager.clearFocus(force = true)
+        }
     }
 
     val message = if (firstPin == null) {
@@ -134,6 +139,7 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
     val focusRequester = remember { FocusRequester() }
     val storedPinLength = remember { pinManager.getPinLength() }
     val hideKeyboard = rememberKeyboardHider()
+    val focusManager = LocalFocusManager.current
 
     LaunchedEffect(pin) {
         if (reveal) {
@@ -144,7 +150,10 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
     DisposableEffect(Unit) {
-        onDispose { hideKeyboard() }
+        onDispose {
+            hideKeyboard()
+            focusManager.clearFocus(force = true)
+        }
     }
 
     Box(

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -28,6 +29,7 @@ fun SettingsScreen(
     var showDialog by remember { mutableStateOf(false) }
     var selectedUri by remember { mutableStateOf<Uri?>(null) }
     val hideKeyboard = rememberKeyboardHider()
+    val focusManager = LocalFocusManager.current
     val importLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.GetContent()
     ) { uri ->
@@ -49,6 +51,7 @@ fun SettingsScreen(
     DisposableEffect(Unit) {
         onDispose {
             hideKeyboard()
+            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }


### PR DESCRIPTION
## Summary
- clear focus when leaving the edit note screen to avoid lingering selections
- apply the same focus reset to add note, settings, PIN, and note list search composables

## Testing
- ./gradlew --console=plain lint

------
https://chatgpt.com/codex/tasks/task_e_68c961efc5948320a0db2278a7a023e1