### PR TITLE
Warm up QSPM service for early driver queries

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
+        android:name=".StarbuckNoteTakerApp"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
@@ -39,7 +40,8 @@
         <!-- QSPM binder implementation for compatibility with vendor GPU drivers -->
         <service
             android:name=".QspmService"
-            android:exported="true">
+            android:exported="true"
+            android:process=":qspm">
             <intent-filter>
                 <action android:name="com.example.starbucknotetaker.IQspmService" />
                 <action android:name="com.qualcomm.qspm.IQspmService" />

--- a/app/src/main/java/com/example/starbucknotetaker/QspmService.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/QspmService.kt
@@ -1,6 +1,7 @@
 package com.example.starbucknotetaker
 
 import android.app.Service
+import android.content.Context
 import android.content.Intent
 import android.os.Binder
 import android.os.IBinder
@@ -203,9 +204,13 @@ class QspmService : Service() {
 
     companion object {
         private const val TAG = "QspmService"
-        private val ACCEPTED_ACTIONS = setOf(
-            "com.example.starbucknotetaker.IQspmService",
-            "com.qualcomm.qspm.IQspmService"
-        )
+
+        const val ACTION_APP_INTERFACE = "com.example.starbucknotetaker.IQspmService"
+        const val ACTION_VENDOR_INTERFACE = "com.qualcomm.qspm.IQspmService"
+
+        private val ACCEPTED_ACTIONS = setOf(ACTION_APP_INTERFACE, ACTION_VENDOR_INTERFACE)
+
+        fun createBindIntent(context: Context, action: String = ACTION_VENDOR_INTERFACE): Intent =
+            Intent(action).setClass(context, QspmService::class.java)
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/QspmServiceInitializer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/QspmServiceInitializer.kt
@@ -1,0 +1,90 @@
+package com.example.starbucknotetaker
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Proactively spins up [QspmService] so vendor drivers can bind to the AIDL
+ * interface even before the UI process runs.
+ */
+object QspmServiceInitializer {
+    private val bindingInProgress = AtomicBoolean(false)
+    private val handler = Handler(Looper.getMainLooper())
+
+    /**
+     * Attempts to bind to [QspmService] momentarily which forces Android to
+     * create the remote process and perform any lazy initialisation.
+     */
+    fun warmUp(context: Context) {
+        val appContext = context.applicationContext
+        if (!bindingInProgress.compareAndSet(false, true)) {
+            Log.d(TAG, "Skipping QSPM warm up; a bind is already in progress")
+            return
+        }
+
+        lateinit var connection: ServiceConnection
+        lateinit var timeoutRunnable: Runnable
+
+        fun releaseBinding() {
+            handler.removeCallbacks(timeoutRunnable)
+            if (!bindingInProgress.compareAndSet(true, false)) {
+                return
+            }
+            runCatching {
+                appContext.unbindService(connection)
+            }.onFailure { error ->
+                Log.w(TAG, "Failed to tear down QSPM warm up binding", error)
+            }
+        }
+
+        timeoutRunnable = Runnable { releaseBinding() }
+        connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                handler.post { releaseBinding() }
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                handler.post { releaseBinding() }
+            }
+
+            override fun onBindingDied(name: ComponentName?) {
+                handler.post { releaseBinding() }
+            }
+
+            override fun onNullBinding(name: ComponentName?) {
+                handler.post { releaseBinding() }
+            }
+        }
+
+        Log.d(TAG, "Requesting warm up bind to QSPM service")
+
+        val bound = runCatching {
+            appContext.bindService(
+                QspmService.createBindIntent(appContext),
+                connection,
+                Context.BIND_AUTO_CREATE
+            )
+        }.getOrElse { error ->
+            Log.w(TAG, "Unable to bind to QSPM service for warm up", error)
+            bindingInProgress.set(false)
+            return
+        }
+
+        if (!bound) {
+            Log.w(TAG, "System rejected QSPM warm up binding request")
+            bindingInProgress.set(false)
+            return
+        }
+
+        handler.postDelayed(timeoutRunnable, BIND_TIMEOUT_MS)
+    }
+
+    private const val BIND_TIMEOUT_MS = 5_000L
+    private const val TAG = "QspmServiceInit"
+}

--- a/app/src/main/java/com/example/starbucknotetaker/StarbuckNoteTakerApp.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/StarbuckNoteTakerApp.kt
@@ -1,0 +1,46 @@
+package com.example.starbucknotetaker
+
+import android.app.ActivityManager
+import android.app.Application
+import android.content.Context
+import android.os.Build
+import android.os.Process
+import android.util.Log
+
+/**
+ * Application entry point used to perform lightweight service warm up for
+ * Qualcomm GPU drivers.
+ */
+class StarbuckNoteTakerApp : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        val processName = resolveProcessName()
+        if (processName == null || processName == packageName) {
+            QspmServiceInitializer.warmUp(this)
+        } else {
+            Log.d(TAG, "Skipping main process initialisation for $processName")
+        }
+    }
+
+    private fun resolveProcessName(): String? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            Application.getProcessName()
+        } else {
+            currentProcessNameLegacy(this, Process.myPid())
+        }
+    }
+
+    companion object {
+        private const val TAG = "StarbuckApp"
+
+        private fun currentProcessNameLegacy(context: Context, pid: Int): String? {
+            val manager = context.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+                ?: return null
+            return runCatching { manager.runningAppProcesses }
+                .getOrNull()
+                ?.firstOrNull { it.pid == pid }
+                ?.processName
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- run `QspmService` in its own `:qspm` process and register the application class
- add a `QspmServiceInitializer` that proactively binds to the vendor AIDL interface so the driver can connect before the UI launches
- expose helper constants and a factory on `QspmService` for reusable binding intents

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68c974ee807483208b4b7398eba57e0b