### PR TITLE
Refine penguin native loading and add coverage

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
@@ -1,0 +1,52 @@
+package com.example.starbucknotetaker
+
+import org.tensorflow.lite.Interpreter
+import org.tensorflow.lite.Tensor
+import java.nio.MappedByteBuffer
+
+/** Lightweight abstraction over TensorFlow Lite interpreter APIs used by [Summarizer]. */
+interface LiteInterpreter {
+    val inputTensorCount: Int
+    fun getOutputTensor(index: Int): LiteTensor
+    fun getInputTensor(index: Int): LiteTensor
+    fun run(inputs: Array<Any>, outputs: Array<Any>)
+    fun runForMultipleInputsOutputs(inputs: Array<Any?>, outputs: Map<Int, Any>)
+    fun close()
+}
+
+/** Simplified view of a TensorFlow Lite tensor. */
+interface LiteTensor {
+    fun shape(): IntArray
+    fun numElements(): Int
+}
+
+/** Default factory creating [LiteInterpreter] instances backed by TensorFlow Lite. */
+class TfLiteInterpreter private constructor(private val delegate: Interpreter) : LiteInterpreter {
+    override val inputTensorCount: Int
+        get() = delegate.inputTensorCount
+
+    override fun getOutputTensor(index: Int): LiteTensor = TfLiteTensor(delegate.getOutputTensor(index))
+
+    override fun getInputTensor(index: Int): LiteTensor = TfLiteTensor(delegate.getInputTensor(index))
+
+    override fun run(inputs: Array<Any>, outputs: Array<Any>) {
+        delegate.run(inputs, outputs)
+    }
+
+    override fun runForMultipleInputsOutputs(inputs: Array<Any?>, outputs: Map<Int, Any>) {
+        delegate.runForMultipleInputsOutputs(inputs, outputs)
+    }
+
+    override fun close() {
+        delegate.close()
+    }
+
+    companion object {
+        fun create(model: MappedByteBuffer): LiteInterpreter = TfLiteInterpreter(Interpreter(model))
+    }
+}
+
+private class TfLiteTensor(private val delegate: Tensor) : LiteTensor {
+    override fun shape(): IntArray = delegate.shape()
+    override fun numElements(): Int = delegate.numElements()
+}

--- a/app/src/test/java/com/example/starbucknotetaker/NativeLibraryLoaderTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NativeLibraryLoaderTest.kt
@@ -1,0 +1,40 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import java.util.concurrent.atomic.AtomicBoolean
+
+class NativeLibraryLoaderTest {
+    private val context: Context = mock()
+
+    @After
+    fun tearDown() {
+        NativeLibraryLoader.setLoadLibraryOverrideForTesting(null)
+        resetPenguinFlag()
+    }
+
+    @Test
+    fun ensurePenguinReturnsTrueWhenLibraryLoads() {
+        NativeLibraryLoader.setLoadLibraryOverrideForTesting { }
+        val loaded = NativeLibraryLoader.ensurePenguin(context)
+        assertTrue(loaded)
+        assertTrue(isPenguinLoaded())
+    }
+
+    private fun resetPenguinFlag() {
+        val field = NativeLibraryLoader::class.java.getDeclaredField("penguinLoaded")
+        field.isAccessible = true
+        val flag = field.get(NativeLibraryLoader) as AtomicBoolean
+        flag.set(false)
+    }
+
+    private fun isPenguinLoaded(): Boolean {
+        val field = NativeLibraryLoader::class.java.getDeclaredField("penguinLoaded")
+        field.isAccessible = true
+        val flag = field.get(NativeLibraryLoader) as AtomicBoolean
+        return flag.get()
+    }
+}


### PR DESCRIPTION
## Summary
- ensure NativeLibraryLoader only loads libpenguin and expose a test hook for System.loadLibrary overrides
- introduce a LiteInterpreter wrapper so Summarizer can inject fake interpreters during tests
- add unit tests covering the NativeLibraryLoader path and the warm-up happy path

## Testing
- ./gradlew testDebugUnitTest --console=plain
- ./gradlew assembleDebug --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68c97a22b0b48320908a64c05d783ccb