### PR TITLE
Handle keyboard dismissal before leaving screens

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -76,8 +76,6 @@ fun AddNoteScreen(
 
     DisposableEffect(Unit) {
         onDispose {
-            hideKeyboard()
-            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }
@@ -89,6 +87,7 @@ fun AddNoteScreen(
                 navigationIcon = {
                     IconButton(onClick = {
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         onBack()
                     }) {
                         Icon(
@@ -128,6 +127,7 @@ fun AddNoteScreen(
                             }
                         }.trim()
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         onSave(title, content, imageList, fileList)
                     }) {
                         Icon(Icons.Default.Check, contentDescription = "Save")

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -167,8 +167,6 @@ fun EditNoteScreen(
 
     DisposableEffect(Unit) {
         onDispose {
-            hideKeyboard()
-            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }
@@ -181,6 +179,7 @@ fun EditNoteScreen(
                 navigationIcon = {
                     IconButton(onClick = {
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         scope.launch {
                             scaffoldState.snackbarHostState.showSnackbar(
                                 "Changes discarded",
@@ -219,6 +218,7 @@ fun EditNoteScreen(
                             }
                         }.trim()
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         scope.launch {
                             onSave(title, content, images, files)
                             scaffoldState.snackbarHostState.showSnackbar(

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -54,13 +54,6 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
     }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            hideKeyboard()
-            focusManager.clearFocus(force = true)
-        }
-    }
-
     val message = if (firstPin == null) {
         "Create a custom PIN"
     } else {
@@ -116,6 +109,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
                 } else {
                     if (pin == firstPin) {
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         pinManager.setPin(pin)
                         onDone(pin)
                     } else {
@@ -149,13 +143,6 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
     }
     LaunchedEffect(Unit) { focusRequester.requestFocus() }
 
-    DisposableEffect(Unit) {
-        onDispose {
-            hideKeyboard()
-            focusManager.clearFocus(force = true)
-        }
-    }
-
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -181,6 +168,7 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
                         if (input.length == storedPinLength) {
                             if (pinManager.checkPin(input)) {
                                 hideKeyboard()
+                                focusManager.clearFocus(force = true)
                                 onSuccess(input)
                             } else {
                                 error = true

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -50,8 +50,6 @@ fun SettingsScreen(
 
     DisposableEffect(Unit) {
         onDispose {
-            hideKeyboard()
-            focusManager.clearFocus(force = true)
             onEnablePinCheck()
         }
     }
@@ -62,6 +60,7 @@ fun SettingsScreen(
         AlertDialog(
             onDismissRequest = {
                 hideKeyboard()
+                focusManager.clearFocus(force = true)
                 showDialog = false
             },
             title = { Text("Import Archive") },
@@ -95,6 +94,7 @@ fun SettingsScreen(
             confirmButton = {
                 TextButton(onClick = {
                     hideKeyboard()
+                    focusManager.clearFocus(force = true)
                     selectedUri?.let { onImport(it, pin, overwrite) }
                     showDialog = false
                 }) { Text("Import") }
@@ -102,6 +102,7 @@ fun SettingsScreen(
             dismissButton = {
                 TextButton(onClick = {
                     hideKeyboard()
+                    focusManager.clearFocus(force = true)
                     showDialog = false
                 }) { Text("Cancel") }
             }
@@ -115,6 +116,7 @@ fun SettingsScreen(
                 navigationIcon = {
                     IconButton(onClick = {
                         hideKeyboard()
+                        focusManager.clearFocus(force = true)
                         onBack()
                     }) {
                         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back")


### PR DESCRIPTION
## Summary
- stop calling hideKeyboard from DisposableEffect cleanups so the keyboard controller is not used after disposal
- clear focus alongside hiding the keyboard when navigating away or saving in the add, edit, settings, and PIN flows
- ensure PIN entry/setup dismiss the keyboard before invoking success callbacks

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68c985b8fa548320a65d578c652830e5