### PR TITLE
Ensure focus cleared before navigating away

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -178,9 +178,9 @@ fun EditNoteScreen(
                 title = { Text("Edit Note") },
                 navigationIcon = {
                     IconButton(onClick = {
-                        hideKeyboard()
-                        focusManager.clearFocus(force = true)
                         scope.launch {
+                            hideKeyboard()
+                            focusManager.clearFocus(force = true)
                             scaffoldState.snackbarHostState.showSnackbar(
                                 "Changes discarded",
                                 duration = SnackbarDuration.Short
@@ -217,9 +217,9 @@ fun EditNoteScreen(
                                 }
                             }
                         }.trim()
-                        hideKeyboard()
-                        focusManager.clearFocus(force = true)
                         scope.launch {
+                            hideKeyboard()
+                            focusManager.clearFocus(force = true)
                             onSave(title, content, images, files)
                             scaffoldState.snackbarHostState.showSnackbar(
                                 "Changes saved",

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -45,17 +45,18 @@ fun NoteListScreen(
     }
     var openIndex by remember { mutableStateOf<Int?>(null) }
     val focusManager = LocalFocusManager.current
-
-    DisposableEffect(Unit) {
-        onDispose { focusManager.clearFocus(force = true) }
-    }
+    val hideKeyboard = rememberKeyboardHider()
     Scaffold(
         floatingActionButton = {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(16.dp)
             ) {
                 FloatingActionButton(
-                    onClick = onSettings,
+                    onClick = {
+                        hideKeyboard()
+                        focusManager.clearFocus(force = true)
+                        onSettings()
+                    },
                     backgroundColor = MaterialTheme.colors.primary
                 ) {
                     Icon(
@@ -65,7 +66,11 @@ fun NoteListScreen(
                     )
                 }
                 FloatingActionButton(
-                    onClick = onAddNote,
+                    onClick = {
+                        hideKeyboard()
+                        focusManager.clearFocus(force = true)
+                        onAddNote()
+                    },
                     backgroundColor = MaterialTheme.colors.primary
                 ) {
                     Icon(
@@ -102,7 +107,11 @@ fun NoteListScreen(
                         isOpen = openIndex == originalIndex,
                         onOpen = { openIndex = originalIndex },
                         onClose = { if (openIndex == originalIndex) openIndex = null },
-                        onClick = { onOpenNote(originalIndex) },
+                        onClick = {
+                            hideKeyboard()
+                            focusManager.clearFocus(force = true)
+                            onOpenNote(originalIndex)
+                        },
                         onDelete = {
                             onDeleteNote(originalIndex)
                             if (openIndex == originalIndex) openIndex = null


### PR DESCRIPTION
## Summary
- move keyboard hiding and focus clearing directly before navigation events in edit and list screens
- clear focus before launching navigation from note list buttons instead of relying on DisposableEffect

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68c988d1000c8320866156d3fdeb6300