### PR TITLE
Add integrity verification for downloaded models

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ModelDownloadWorker.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ModelDownloadWorker.kt
@@ -15,6 +15,7 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import java.io.File
 import java.io.FileOutputStream
+import java.security.MessageDigest
 import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.delay
 
@@ -34,7 +35,33 @@ class ModelDownloadWorker(
     companion object {
         private const val MAX_ATTEMPTS = 3
         private const val RETRY_BASE_DELAY_MS = 1_000L
+
+        private val EXPECTED_FILES = mapOf(
+            ModelFetcher.ENCODER_NAME to ExpectedFile(
+                kind = FileKind.TFLITE,
+                sizeBytes = 35_986_000L,
+                sha256 = "e38daf1645972bbf8e096dc5f2c030c17f5114d4295d2161f59d1b0a8261091c"
+            ),
+            ModelFetcher.DECODER_NAME to ExpectedFile(
+                kind = FileKind.TFLITE,
+                sizeBytes = 59_264_176L,
+                sha256 = "34a39fac38e371888f3a2bf79ce37c938e226252f37f41ff6ab79ce09922c4df"
+            ),
+            ModelFetcher.SPIECE_NAME to ExpectedFile(
+                kind = FileKind.SENTENCE_PIECE,
+                sizeBytes = 791_656L,
+                sha256 = "d60acb128cf7b7f2536e8f38a5b18a05535c9e14c7a355904270e15b0945ea86"
+            )
+        )
     }
+
+    private data class ExpectedFile(
+        val kind: FileKind,
+        val sizeBytes: Long,
+        val sha256: String
+    )
+
+    private enum class FileKind { TFLITE, SENTENCE_PIECE }
 
     override suspend fun doWork(): Result {
         val baseUrl = inputData.getString("baseUrl") ?: return Result.failure()
@@ -53,13 +80,13 @@ class ModelDownloadWorker(
             val url = baseUrl + remote
             val dest = File(modelsDir, name)
             try {
-                Log.d("Summarizer", "summarizer: downloading ${'$'}name")
-                download(url, dest)
+                Log.d("Summarizer", "summarizer: downloading $name")
+                download(name, url, dest)
                 progress += 100 / tasks.size
                 setForeground(createForegroundInfo(progress))
-                Log.d("Summarizer", "summarizer: downloaded ${'$'}name")
+                Log.d("Summarizer", "summarizer: downloaded $name")
             } catch (t: Throwable) {
-                Log.e("Summarizer", "summarizer: failed downloading ${'$'}name", t)
+                Log.e("Summarizer", "summarizer: failed downloading $name", t)
                 return Result.failure(
                     workDataOf(
                         "error" to (t.message ?: t::class.java.simpleName ?: "download failed"),
@@ -73,17 +100,17 @@ class ModelDownloadWorker(
         return Result.success()
     }
 
-    private suspend fun download(url: String, dest: File) {
+    private suspend fun download(name: String, url: String, dest: File) {
         var lastError: Throwable? = null
         repeat(MAX_ATTEMPTS) { attempt ->
             try {
                 val request = Request.Builder().url(url).get().build()
                 dest.parentFile?.mkdirs()
-                val tmp = File(dest.parentFile, "${'$'}{dest.name}.download")
+                val tmp = File(dest.parentFile, "${dest.name}.download")
                 if (tmp.exists()) tmp.delete()
                 client.newCall(request).execute().use { resp ->
-                    if (!resp.isSuccessful) error("HTTP ${'$'}{resp.code}: ${'$'}url")
-                    val body = resp.body ?: error("Empty body: ${'$'}url")
+                    if (!resp.isSuccessful) error("HTTP ${resp.code}: $url")
+                    val body = resp.body ?: error("Empty body: $url")
                     body.use { responseBody ->
                         FileOutputStream(tmp).use { out ->
                             responseBody.byteStream().use { ins ->
@@ -96,24 +123,106 @@ class ModelDownloadWorker(
                     tmp.copyTo(dest, overwrite = true)
                     tmp.delete()
                 }
+                if (!verifyDownloadedFile(name, dest)) {
+                    dest.delete()
+                    throw IllegalStateException("Integrity check failed for $name")
+                }
                 return
             } catch (t: Throwable) {
                 lastError = t
                 dest.delete()
-                val tmp = File(dest.parentFile, "${'$'}{dest.name}.download")
+                val tmp = File(dest.parentFile, "${dest.name}.download")
                 tmp.delete()
                 if (attempt < MAX_ATTEMPTS - 1) {
                     val delayMs = RETRY_BASE_DELAY_MS shl attempt
                     Log.w(
                         "Summarizer",
-                        "summarizer: retrying download ${'$'}url in ${'$'}delayMs ms (attempt ${'$'}{attempt + 2} of ${'$'}MAX_ATTEMPTS)",
+                        "summarizer: retrying download $url in $delayMs ms (attempt ${attempt + 2} of $MAX_ATTEMPTS)",
                         t
                     )
                     delay(delayMs)
                 }
             }
         }
-        throw lastError ?: IllegalStateException("Failed to download ${'$'}url")
+        throw lastError ?: IllegalStateException("Failed to download $url")
+    }
+
+    private fun verifyDownloadedFile(name: String, file: File): Boolean {
+        if (!file.exists()) {
+            Log.e("Summarizer", "summarizer: downloaded file missing for $name")
+            return false
+        }
+
+        val expected = EXPECTED_FILES[name]
+        val kind = expected?.kind ?: inferKind(name)
+        var valid = true
+
+        val size = file.length()
+        if (size <= 0) {
+            Log.e("Summarizer", "summarizer: size mismatch for $name (empty file)")
+            valid = false
+        }
+
+        if (expected != null && size != expected.sizeBytes) {
+            Log.e(
+                "Summarizer",
+                "summarizer: size mismatch for $name (expected ${expected.sizeBytes} bytes, actual $size bytes)"
+            )
+            valid = false
+        }
+
+        if (kind == FileKind.TFLITE && !ModelFetcher.hasTfliteMagic(file)) {
+            Log.e(
+                "Summarizer",
+                "summarizer: invalid TFLite header for $name (first bytes: ${headerPreview(file)})"
+            )
+            valid = false
+        }
+
+        if (expected != null) {
+            val actualHash = sha256(file)
+            if (!actualHash.equals(expected.sha256, ignoreCase = true)) {
+                Log.e(
+                    "Summarizer",
+                    "summarizer: sha256 mismatch for $name (expected ${expected.sha256}, actual $actualHash)"
+                )
+                valid = false
+            }
+        }
+
+        if (valid) {
+            Log.d(
+                "Summarizer",
+                "summarizer: integrity check passed for $name ($size bytes)"
+            )
+        }
+
+        return valid
+    }
+
+    private fun inferKind(name: String): FileKind =
+        if (name.endsWith(".tflite", ignoreCase = true)) FileKind.TFLITE else FileKind.SENTENCE_PIECE
+
+    private fun headerPreview(file: File, byteCount: Int = 8): String {
+        val header = ByteArray(byteCount)
+        val read = file.inputStream().use { it.read(header) }
+        if (read <= 0) return ""
+        return header.take(read).joinToString(separator = " ") { b ->
+            "%02x".format(b.toInt() and 0xff)
+        }
+    }
+
+    private fun sha256(file: File): String {
+        val md = MessageDigest.getInstance("SHA-256")
+        file.inputStream().use { ins ->
+            val buffer = ByteArray(DEFAULT_BUFFER_SIZE)
+            while (true) {
+                val read = ins.read(buffer)
+                if (read <= 0) break
+                md.update(buffer, 0, read)
+            }
+        }
+        return md.digest().joinToString("") { byte -> "%02x".format(byte) }
     }
 
     private fun createForegroundInfo(progress: Int): ForegroundInfo {


### PR DESCRIPTION
## Summary
- Verified the encoder, decoder, and tokenizer URLs return the expected binary content by checking magic bytes, sizes, and SHA-256 hashes.
- Relaxed ModelFetcher TFLite validation to accept files whose magic appears at byte offset four, matching the downloaded FlatBuffer layout.
- Added per-file integrity checks in ModelDownloadWorker that compare size and SHA-256 values and log detailed diagnostics when mismatches occur.

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c988d8ec7883209c6e1fb3c9463048