### PR TITLE
Fix Android CI SDK configuration

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -26,6 +26,16 @@ jobs:
             platform-tools
             platforms;android-34
             build-tools;34.0.0
+            ndk;26.1.10909125
+
+      - name: Configure local.properties
+        run: |
+          SDK_PATH="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+          if [ -z "$SDK_PATH" ]; then
+            echo "Android SDK path not available" >&2
+            exit 1
+          fi
+          echo "sdk.dir=$SDK_PATH" > local.properties
 
       - name: Make Gradle wrapper executable
         run: chmod +x ./gradlew

--- a/local.properties
+++ b/local.properties
@@ -1,1 +1,0 @@
-sdk.dir=/root/.android-sdk


### PR DESCRIPTION
## Summary
- install the Android NDK in the CI workflow to satisfy the native build
- generate local.properties in CI so Gradle uses the SDK provisioned by the workflow
- drop the stale local.properties file from version control

## Testing
- ./gradlew --version

------
https://chatgpt.com/codex/tasks/task_e_68c99b87315c83208aa3a14b23ba50cf