### PR TITLE
Install DJL sentencepiece native library on Android

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
@@ -1,17 +1,27 @@
 package com.example.starbucknotetaker
 
+import android.content.Context
+import android.util.Log
 import ai.djl.sentencepiece.SpTokenizer
+import ai.djl.util.Platform
+import ai.djl.util.Utils
 import java.io.File
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Wrapper around DJL's SentencePiece tokenizer providing simple encode/decode
  * helpers used by the T5 summarization model.
  */
-class SentencePieceProcessor {
+class SentencePieceProcessor(
+    private val nativeInstaller: (Context) -> Unit = { SentencePieceNativeInstaller.ensureInstalled(it) }
+) {
     private lateinit var tokenizer: SpTokenizer
 
     /** Loads the SentencePiece model from [modelPath]. */
-    fun load(modelPath: String) {
+    fun load(context: Context, modelPath: String) {
+        nativeInstaller(context)
         File(modelPath).inputStream().use { inputStream ->
             tokenizer = SpTokenizer(inputStream)
         }
@@ -26,6 +36,79 @@ class SentencePieceProcessor {
     /** Releases native resources. */
     fun close() {
         tokenizer.close()
+    }
+}
+
+private object SentencePieceNativeInstaller {
+    private const val TAG = "SentencePieceInstaller"
+    private val installed = AtomicBoolean(false)
+
+    fun ensureInstalled(context: Context) {
+        if (installed.get()) return
+        synchronized(this) {
+            if (installed.get()) return
+            val destination = resolveDestinationFile() ?: run {
+                Log.w(TAG, "Unable to determine DJL cache directory for SentencePiece native library")
+                return
+            }
+            if (destination.exists() && destination.length() > 0) {
+                installed.set(true)
+                return
+            }
+            val source = findSourceLibrary(context) ?: run {
+                Log.w(TAG, "Could not locate packaged SentencePiece native library to install")
+                return
+            }
+            val parent = destination.parentFile
+            if (parent == null) {
+                Log.w(TAG, "SentencePiece destination has no parent directory: ${destination.absolutePath}")
+                return
+            }
+            if (!parent.exists() && !parent.mkdirs() && !parent.exists()) {
+                Log.w(TAG, "Failed to create directory for SentencePiece native library at ${parent.absolutePath}")
+                return
+            }
+            try {
+                source.inputStream().use { input ->
+                    FileOutputStream(destination).use { output ->
+                        input.copyTo(output)
+                    }
+                }
+                destination.setReadable(true, false)
+                destination.setExecutable(true, false)
+                destination.setWritable(true, true)
+                installed.set(true)
+                Log.d(TAG, "Installed SentencePiece native library for DJL at ${destination.absolutePath}")
+            } catch (io: IOException) {
+                Log.w(TAG, "Failed copying SentencePiece native library to DJL cache", io)
+                destination.delete()
+            } catch (t: Throwable) {
+                Log.w(TAG, "Unexpected failure while installing SentencePiece native library", t)
+                destination.delete()
+            }
+        }
+    }
+
+    private fun resolveDestinationFile(): File? =
+        try {
+            val cacheDir = Utils.getEngineCacheDir("sentencepiece")
+            val platform = Platform.detectPlatform("sentencepiece")
+            val version = platform.version
+            cacheDir.resolve(version).resolve(System.mapLibraryName("sentencepiece_native")).toFile()
+        } catch (t: Throwable) {
+            Log.w(TAG, "Failed resolving DJL cache path for SentencePiece", t)
+            null
+        }
+
+    private fun findSourceLibrary(context: Context): File? {
+        val candidates = listOf("penguin", "djl_tokenizer", "sentencepiece_native")
+        for (name in candidates) {
+            val file = NativeLibraryLoader.findLibraryOnDisk(context, name)
+            if (file != null && file.exists() && file.length() > 0) {
+                return file
+            }
+        }
+        return null
     }
 }
 

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -21,7 +21,7 @@ import java.nio.channels.FileChannel
 class Summarizer(
     private val context: Context,
     private val fetcher: ModelFetcher = ModelFetcher(),
-    private val spFactory: () -> SentencePieceProcessor = { SentencePieceProcessor() },
+    private val spFactory: (Context) -> SentencePieceProcessor = { SentencePieceProcessor() },
     private val nativeLoader: (Context) -> Boolean = { NativeLibraryLoader.ensurePenguin(it) },
     private val interpreterFactory: (MappedByteBuffer) -> LiteInterpreter = { TfLiteInterpreter.create(it) },
     private val logger: (String, Throwable) -> Unit = { msg, t -> Log.e("Summarizer", "summarizer: $msg", t) },
@@ -58,7 +58,7 @@ class Summarizer(
                     }
                     encoder = interpreterFactory(mapFile(result.encoder))
                     decoder = interpreterFactory(mapFile(result.decoder))
-                    tokenizer = spFactory().apply { load(result.spiece.absolutePath) }
+                    tokenizer = spFactory(context).apply { load(context, result.spiece.absolutePath) }
                     debug("summarizer models ready")
                     _state.emit(SummarizerState.Ready)
                 } catch (e: Throwable) {

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -107,7 +107,7 @@ class SummarizerTest {
         val summarizer = Summarizer(
             context,
             fetcher = fetcher,
-            spFactory = { tokenizer },
+            spFactory = { _ -> tokenizer },
             nativeLoader = { NativeLibraryLoader.ensurePenguin(it) },
             interpreterFactory = { interpreters.removeFirst() },
             logger = { _, _ -> },


### PR DESCRIPTION
## Summary
- ensure the SentencePieceProcessor installs the DJL native library into the expected cache before creating the tokenizer
- add a NativeLibraryLoader helper to locate packaged JNI libraries so they can be copied for DJL
- pass Android context into the tokenizer factory and update tests for the new signature

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c99f692b808320992f57c6563ed84d