### PR TITLE
Fix tokenizer loading and show summarizer status

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -152,8 +152,8 @@ dependencies {
     implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
-    implementation 'ai.djl.sentencepiece:sentencepiece:0.33.0'
     implementation 'ai.djl.android:tokenizer-native:0.33.0'
+    implementation 'ai.djl.huggingface:tokenizers:0.33.0'
     implementation 'com.getkeepsafe.relinker:relinker:1.4.5'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
@@ -187,7 +187,6 @@ def preparePenguinNativeLibs = tasks.register('preparePenguinNativeLibs', Sync) 
     eachFile { file ->
         file.path = file.path
                 .replaceFirst('jni/', '')
-                .replace('libdjl_tokenizer.so', 'libpenguin.so')
     }
     includeEmptyDirs = false
     into(penguinNativeLibsDir)

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -50,6 +50,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
     var pinCheckEnabled by remember { mutableStateOf(true) }
     var lastRoute by rememberSaveable { mutableStateOf<String?>(null) }
     val lifecycleOwner = LocalLifecycleOwner.current
+    val summarizerState by noteViewModel.summarizerState.collectAsState()
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
@@ -114,7 +115,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 onAddNote = { navController.navigate("add") },
                 onOpenNote = { index -> navController.navigate("detail/$index") },
                 onDeleteNote = { index -> noteViewModel.deleteNote(index) },
-                onSettings = { navController.navigate("settings") }
+                onSettings = { navController.navigate("settings") },
+                summarizerState = summarizerState
             )
         }
         composable("add") {
@@ -125,7 +127,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 },
                 onBack = { navController.popBackStack() },
                 onDisablePinCheck = { pinCheckEnabled = false },
-                onEnablePinCheck = { pinCheckEnabled = true }
+                onEnablePinCheck = { pinCheckEnabled = true },
+                summarizerState = summarizerState
             )
         }
         composable("detail/{index}") { backStackEntry ->
@@ -151,7 +154,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                     },
                     onCancel = { navController.popBackStack() },
                     onDisablePinCheck = { pinCheckEnabled = false },
-                    onEnablePinCheck = { pinCheckEnabled = true }
+                    onEnablePinCheck = { pinCheckEnabled = true },
+                    summarizerState = summarizerState
                 )
             }
         }

--- a/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/SentencePieceProcessor.kt
@@ -1,114 +1,50 @@
 package com.example.starbucknotetaker
 
 import android.content.Context
-import android.util.Log
-import ai.djl.sentencepiece.SpTokenizer
-import ai.djl.util.Platform
-import ai.djl.util.Utils
+import ai.djl.huggingface.tokenizers.HuggingFaceTokenizer
 import java.io.File
-import java.io.FileOutputStream
-import java.io.IOException
-import java.util.concurrent.atomic.AtomicBoolean
+import java.io.FileInputStream
 
 /**
- * Wrapper around DJL's SentencePiece tokenizer providing simple encode/decode
- * helpers used by the T5 summarization model.
+ * Wrapper around DJL's HuggingFace tokenizer providing encode/decode helpers
+ * used by the T5 summarization model.
  */
 class SentencePieceProcessor(
-    private val nativeInstaller: (Context) -> Unit = { SentencePieceNativeInstaller.ensureInstalled(it) }
-) {
-    private lateinit var tokenizer: SpTokenizer
-
-    /** Loads the SentencePiece model from [modelPath]. */
-    fun load(context: Context, modelPath: String) {
-        nativeInstaller(context)
-        File(modelPath).inputStream().use { inputStream ->
-            tokenizer = SpTokenizer(inputStream)
+    private val tokenizerFactory: (Context, File) -> HuggingFaceTokenizer = { _, file ->
+        FileInputStream(file).use { stream ->
+            HuggingFaceTokenizer.newInstance(stream, emptyMap())
         }
+    }
+) {
+    private var tokenizer: HuggingFaceTokenizer? = null
+
+    /** Loads the tokenizer model from [modelPath]. */
+    fun load(context: Context, modelPath: String) {
+        close()
+        val file = File(modelPath)
+        if (!file.exists()) {
+            throw IllegalArgumentException("Tokenizer model missing at $modelPath")
+        }
+        tokenizer = tokenizerFactory(context, file)
     }
 
     /** Encodes [text] into an array of token IDs. */
-    fun encodeAsIds(text: String): IntArray = tokenizer.processor.encode(text)
+    fun encodeAsIds(text: String): IntArray {
+        val encoding = tokenizer?.encode(text)
+            ?: throw IllegalStateException("Tokenizer has not been loaded")
+        return encoding.ids.map { it.toInt() }.toIntArray()
+    }
 
     /** Decodes token [ids] back into a string. */
-    fun decodeIds(ids: IntArray): String = tokenizer.processor.decode(ids)
+    fun decodeIds(ids: IntArray): String {
+        val tok = tokenizer ?: throw IllegalStateException("Tokenizer has not been loaded")
+        val longs = LongArray(ids.size) { idx -> ids[idx].toLong() }
+        return tok.decode(longs, false)
+    }
 
     /** Releases native resources. */
     fun close() {
-        tokenizer.close()
+        tokenizer?.close()
+        tokenizer = null
     }
 }
-
-private object SentencePieceNativeInstaller {
-    private const val TAG = "SentencePieceInstaller"
-    private val installed = AtomicBoolean(false)
-
-    fun ensureInstalled(context: Context) {
-        if (installed.get()) return
-        synchronized(this) {
-            if (installed.get()) return
-            val destination = resolveDestinationFile() ?: run {
-                Log.w(TAG, "Unable to determine DJL cache directory for SentencePiece native library")
-                return
-            }
-            if (destination.exists() && destination.length() > 0) {
-                installed.set(true)
-                return
-            }
-            val source = findSourceLibrary(context) ?: run {
-                Log.w(TAG, "Could not locate packaged SentencePiece native library to install")
-                return
-            }
-            val parent = destination.parentFile
-            if (parent == null) {
-                Log.w(TAG, "SentencePiece destination has no parent directory: ${destination.absolutePath}")
-                return
-            }
-            if (!parent.exists() && !parent.mkdirs() && !parent.exists()) {
-                Log.w(TAG, "Failed to create directory for SentencePiece native library at ${parent.absolutePath}")
-                return
-            }
-            try {
-                source.inputStream().use { input ->
-                    FileOutputStream(destination).use { output ->
-                        input.copyTo(output)
-                    }
-                }
-                destination.setReadable(true, false)
-                destination.setExecutable(true, false)
-                destination.setWritable(true, true)
-                installed.set(true)
-                Log.d(TAG, "Installed SentencePiece native library for DJL at ${destination.absolutePath}")
-            } catch (io: IOException) {
-                Log.w(TAG, "Failed copying SentencePiece native library to DJL cache", io)
-                destination.delete()
-            } catch (t: Throwable) {
-                Log.w(TAG, "Unexpected failure while installing SentencePiece native library", t)
-                destination.delete()
-            }
-        }
-    }
-
-    private fun resolveDestinationFile(): File? =
-        try {
-            val cacheDir = Utils.getEngineCacheDir("sentencepiece")
-            val platform = Platform.detectPlatform("sentencepiece")
-            val version = platform.version
-            cacheDir.resolve(version).resolve(System.mapLibraryName("sentencepiece_native")).toFile()
-        } catch (t: Throwable) {
-            Log.w(TAG, "Failed resolving DJL cache path for SentencePiece", t)
-            null
-        }
-
-    private fun findSourceLibrary(context: Context): File? {
-        val candidates = listOf("penguin", "djl_tokenizer", "sentencepiece_native")
-        for (name in candidates) {
-            val file = NativeLibraryLoader.findLibraryOnDisk(context, name)
-            if (file != null && file.exists() && file.length() > 0) {
-                return file
-            }
-        }
-        return null
-    }
-}
-

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -22,7 +22,7 @@ class Summarizer(
     private val context: Context,
     private val fetcher: ModelFetcher = ModelFetcher(),
     private val spFactory: (Context) -> SentencePieceProcessor = { SentencePieceProcessor() },
-    private val nativeLoader: (Context) -> Boolean = { NativeLibraryLoader.ensurePenguin(it) },
+    private val nativeLoader: (Context) -> Boolean = { NativeLibraryLoader.ensureTokenizer(it) },
     private val interpreterFactory: (MappedByteBuffer) -> LiteInterpreter = { TfLiteInterpreter.create(it) },
     private val logger: (String, Throwable) -> Unit = { msg, t -> Log.e("Summarizer", "summarizer: $msg", t) },
     private val debug: (String) -> Unit = { msg -> Log.d("Summarizer", "summarizer: $msg") }
@@ -51,14 +51,14 @@ class Summarizer(
                     if (!ensureNativeTokenizerLib()) {
                         logger(
                             "summarizer missing native tokenizer lib",
-                            UnsatisfiedLinkError("libpenguin.so not found")
+                            UnsatisfiedLinkError("libdjl_tokenizer.so not found")
                         )
                         _state.emit(SummarizerState.Fallback)
                         return
                     }
                     encoder = interpreterFactory(mapFile(result.encoder))
                     decoder = interpreterFactory(mapFile(result.decoder))
-                    tokenizer = spFactory(context).apply { load(context, result.spiece.absolutePath) }
+                    tokenizer = spFactory(context).apply { load(context, result.tokenizer.absolutePath) }
                     debug("summarizer models ready")
                     _state.emit(SummarizerState.Ready)
                 } catch (e: Throwable) {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -24,13 +24,15 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberAsyncImagePainter
+import com.example.starbucknotetaker.Summarizer
 
 @Composable
 fun AddNoteScreen(
     onSave: (String?, String, List<Pair<Uri, Int>>, List<Uri>) -> Unit,
     onBack: () -> Unit,
     onDisablePinCheck: () -> Unit,
-    onEnablePinCheck: () -> Unit
+    onEnablePinCheck: () -> Unit,
+    summarizerState: Summarizer.SummarizerState
 ) {
     var title by remember { mutableStateOf("") }
     val blocks = remember { mutableStateListOf<NoteBlock>(NoteBlock.Text("")) }
@@ -142,6 +144,9 @@ fun AddNoteScreen(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
+            item {
+                SummarizerStatusBanner(state = summarizerState)
+            }
             item {
                 OutlinedTextField(
                     value = title,

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.dp
 import androidx.exifinterface.media.ExifInterface
 import com.example.starbucknotetaker.Note
 import com.example.starbucknotetaker.NoteFile
+import com.example.starbucknotetaker.Summarizer
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -43,7 +44,8 @@ fun EditNoteScreen(
     onSave: (String?, String, List<String>, List<NoteFile>) -> Unit,
     onCancel: () -> Unit,
     onDisablePinCheck: () -> Unit,
-    onEnablePinCheck: () -> Unit
+    onEnablePinCheck: () -> Unit,
+    summarizerState: Summarizer.SummarizerState
 ) {
     var title by remember { mutableStateOf(note.title) }
     val blocks = remember {
@@ -240,6 +242,9 @@ fun EditNoteScreen(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
+            item {
+                SummarizerStatusBanner(state = summarizerState)
+            }
             item {
                 OutlinedTextField(
                     value = title,

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -11,9 +11,9 @@ import androidx.compose.material.FractionalThreshold
 import androidx.compose.material.rememberSwipeableState
 import androidx.compose.material.swipeable
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.Note
+import com.example.starbucknotetaker.Summarizer
 import java.text.SimpleDateFormat
 import java.util.*
 import kotlinx.coroutines.launch
@@ -35,7 +36,8 @@ fun NoteListScreen(
     onAddNote: () -> Unit,
     onOpenNote: (Int) -> Unit,
     onDeleteNote: (Int) -> Unit,
-    onSettings: () -> Unit
+    onSettings: () -> Unit,
+    summarizerState: Summarizer.SummarizerState
 ) {
     var query by remember { mutableStateOf("") }
     val filtered = notes.filter {
@@ -87,6 +89,7 @@ fun NoteListScreen(
                 .padding(padding)
                 .fillMaxSize()
         ) {
+            SummarizerStatusBanner(state = summarizerState)
             OutlinedTextField(
                 value = query,
                 onValueChange = { query = it },

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SummarizerStatusBanner.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SummarizerStatusBanner.kt
@@ -1,0 +1,99 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ErrorOutline
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.starbucknotetaker.Summarizer
+
+@Composable
+fun SummarizerStatusBanner(
+    state: Summarizer.SummarizerState,
+    modifier: Modifier = Modifier
+) {
+    when (state) {
+        Summarizer.SummarizerState.Ready -> Unit
+        Summarizer.SummarizerState.Loading -> {
+            BannerContainer(
+                background = MaterialTheme.colors.primary.copy(alpha = 0.08f),
+                modifier = modifier
+            ) {
+                CircularProgressIndicator(
+                    strokeWidth = 2.dp,
+                    modifier = Modifier.size(20.dp),
+                    color = MaterialTheme.colors.primary
+                )
+                Spacer(Modifier.size(12.dp))
+                Text("Loading AI summarizer…")
+            }
+        }
+        Summarizer.SummarizerState.Fallback -> {
+            BannerContainer(
+                background = MaterialTheme.colors.primary.copy(alpha = 0.08f),
+                modifier = modifier
+            ) {
+                Icon(
+                    imageVector = Icons.Default.Info,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.primary
+                )
+                Spacer(Modifier.size(12.dp))
+                Text("Using fallback summarization")
+            }
+        }
+        is Summarizer.SummarizerState.Error -> {
+            BannerContainer(
+                background = MaterialTheme.colors.error.copy(alpha = 0.1f),
+                modifier = modifier
+            ) {
+                Icon(
+                    imageVector = Icons.Default.ErrorOutline,
+                    contentDescription = null,
+                    tint = MaterialTheme.colors.error
+                )
+                Spacer(Modifier.size(12.dp))
+                Text("Summarizer unavailable: ${state.message}")
+            }
+        }
+    }
+}
+
+@Composable
+private fun BannerContainer(
+    background: Color,
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit
+) {
+    Surface(
+        color = background,
+        shape = MaterialTheme.shapes.small,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.Start
+        ) {
+            content()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- stop renaming the DJL tokenizer native libraries so `System.loadLibrary("djl_tokenizer")` succeeds and adjust the native loader accordingly
- switch the summarizer tokenizer implementation to the HuggingFace tokenizer runtime, download the `tokenizer.json` model, and update fetch/download logic
- surface summarizer readiness/fallback states in the UI with a shared banner component used on list, add, and edit screens
- update unit tests to the new tokenizer setup

## Testing
- `./gradlew test` *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a7203bdc832098a42417ae59d0fb