### PR TITLE
Fix TFLite encoder invocation

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
@@ -9,7 +9,7 @@ interface LiteInterpreter {
     val inputTensorCount: Int
     fun getOutputTensor(index: Int): LiteTensor
     fun getInputTensor(index: Int): LiteTensor
-    fun run(inputs: Array<Any>, outputs: Array<Any>)
+    fun run(input: Any, output: Any)
     fun runForMultipleInputsOutputs(inputs: Array<Any?>, outputs: Map<Int, Any>)
     fun close()
 }
@@ -29,8 +29,8 @@ class TfLiteInterpreter private constructor(private val delegate: Interpreter) :
 
     override fun getInputTensor(index: Int): LiteTensor = TfLiteTensor(delegate.getInputTensor(index))
 
-    override fun run(inputs: Array<Any>, outputs: Array<Any>) {
-        delegate.run(inputs, outputs)
+    override fun run(input: Any, output: Any) {
+        delegate.run(input, output)
     }
 
     override fun runForMultipleInputsOutputs(inputs: Array<Any?>, outputs: Map<Int, Any>) {

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -128,7 +128,12 @@ class Summarizer(
         val encLength = intArrayOf(encLen)
         val encOutShape = enc.getOutputTensor(0).shape()
         val encHidden = Array(encOutShape[0]) { Array(encOutShape[1]) { FloatArray(encOutShape[2]) } }
-        enc.run(arrayOf(encInput, encLength), arrayOf(encHidden))
+        val encInputs = arrayOfNulls<Any>(2).apply {
+            this[0] = encInput
+            this[1] = encLength
+        }
+        val encOutputs = hashMapOf<Int, Any>(0 to encHidden)
+        enc.runForMultipleInputsOutputs(encInputs, encOutputs)
 
         val numInputs = dec.inputTensorCount
         val cache = Array(numInputs - 3) { FloatArray(dec.getInputTensor(it + 3).numElements()) }


### PR DESCRIPTION
## Summary
- adjust the LiteInterpreter abstraction to match the TensorFlow Lite API
- update the summarizer encoder call to use runForMultipleInputsOutputs for multi-input inference

## Testing
- ./gradlew :app:assembleDebug *(fails: Android SDK not available in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9b601297c8320826366d6db4c1093