### PR TITLE
Handle dynamic tensor shapes for summarizer models

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
@@ -17,6 +17,7 @@ interface LiteInterpreter {
 /** Simplified view of a TensorFlow Lite tensor. */
 interface LiteTensor {
     fun shape(): IntArray
+    fun shapeSignature(): IntArray
     fun numElements(): Int
 }
 
@@ -48,5 +49,6 @@ class TfLiteInterpreter private constructor(private val delegate: Interpreter) :
 
 private class TfLiteTensor(private val delegate: Tensor) : LiteTensor {
     override fun shape(): IntArray = delegate.shape()
+    override fun shapeSignature(): IntArray = delegate.shapeSignature()
     override fun numElements(): Int = delegate.numElements()
 }

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -154,9 +154,11 @@ class SummarizerTest {
 
     private class FakeTensor(
         private val shapeValues: IntArray = intArrayOf(1),
-        private val elements: Int = 1
+        private val elements: Int = 1,
+        private val signatureValues: IntArray = shapeValues
     ) : LiteTensor {
         override fun shape(): IntArray = shapeValues
+        override fun shapeSignature(): IntArray = signatureValues
         override fun numElements(): Int = elements
     }
 }


### PR DESCRIPTION
## Summary
- derive encoder input and output sizes from the interpreter tensor metadata before running inference so zero-dimension shapes default to usable values
- fall back to tensor shape signatures when computing cache buffer sizes to avoid zero-length allocations
- expose tensor shape signatures through the LiteTensor abstraction and update fake tensors used by unit tests

## Testing
- `./gradlew test` *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9bcd4c55c83209d1a39797624baee