### PR TITLE
Set gallery as default picker for image attachments

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -2,6 +2,7 @@ package com.example.starbucknotetaker.ui
 
 import android.content.Intent
 import android.net.Uri
+import android.provider.MediaStore
 import android.provider.OpenableColumns
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -40,7 +41,10 @@ fun AddNoteScreen(
     val hideKeyboard = rememberKeyboardHider()
     val focusManager = LocalFocusManager.current
 
-    val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+    val imagePickerContract = remember {
+        OpenDocumentWithInitialUri(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+    }
+    val imageLauncher = rememberLauncherForActivityResult(imagePickerContract) { uri: Uri? ->
         uri?.let {
             context.contentResolver.takePersistableUriPermission(
                 it,

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -5,8 +5,9 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.graphics.Matrix
 import android.net.Uri
-import android.util.Base64
+import android.provider.MediaStore
 import android.provider.OpenableColumns
+import android.util.Base64
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.Image
@@ -91,7 +92,10 @@ fun EditNoteScreen(
     val hideKeyboard = rememberKeyboardHider()
     val focusManager = LocalFocusManager.current
 
-    val imageLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri: Uri? ->
+    val imagePickerContract = remember {
+        OpenDocumentWithInitialUri(MediaStore.Images.Media.EXTERNAL_CONTENT_URI)
+    }
+    val imageLauncher = rememberLauncherForActivityResult(imagePickerContract) { uri: Uri? ->
         onEnablePinCheck()
         uri?.let {
             context.contentResolver.takePersistableUriPermission(

--- a/app/src/main/java/com/example/starbucknotetaker/ui/OpenDocumentWithInitialUri.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/OpenDocumentWithInitialUri.kt
@@ -1,0 +1,18 @@
+package com.example.starbucknotetaker.ui
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.DocumentsContract
+import androidx.activity.result.contract.ActivityResultContracts
+
+class OpenDocumentWithInitialUri(private val initialUri: Uri?) : ActivityResultContracts.OpenDocument() {
+    override fun createIntent(context: Context, input: Array<String>): Intent {
+        val intent = super.createIntent(context, input)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            initialUri?.let { intent.putExtra(DocumentsContract.EXTRA_INITIAL_URI, it) }
+        }
+        return intent
+    }
+}


### PR DESCRIPTION
## Summary
- add a custom document picker contract that supports seeding an initial location
- point the add and edit note image pickers at the gallery so they open there by default

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68cabb3eb3cc83208397c92e974b07d0