### PR TITLE
Fix summarizer decoding when cache tensors are unavailable

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -103,6 +103,51 @@ class SummarizerTest {
     }
 
     @Test
+    fun summarizeFeedsFullHistoryWhenDecoderLacksCache() = runBlocking {
+        val encFile = File(modelsDir, ModelFetcher.ENCODER_NAME).apply { writeBytes(ByteArray(4)) }
+        val decFile = File(modelsDir, ModelFetcher.DECODER_NAME).apply { writeBytes(ByteArray(4)) }
+        val tokenizerFile = File(modelsDir, ModelFetcher.TOKENIZER_NAME).apply { writeBytes(ByteArray(4)) }
+
+        val fetcher = mock<ModelFetcher>()
+        whenever(fetcher.ensureModels(any())).thenReturn(
+            ModelFetcher.Result.Success(encFile, decFile, tokenizerFile)
+        )
+
+        val tokenizer = mock<SentencePieceProcessor>()
+        val encodedIds = intArrayOf(7, 8, 9)
+        whenever(tokenizer.encodeAsIds(any())).thenReturn(encodedIds)
+        whenever(tokenizer.decodeIds(any())).thenAnswer { invocation ->
+            val ids = invocation.arguments[0] as IntArray
+            ids.joinToString(",")
+        }
+
+        val generatedTokens = intArrayOf(21, 22)
+        val attentionCapacity = max(encodedIds.size, generatedTokens.size + 1)
+        val decoder = DecoderWithoutCacheStub(generatedTokens, attentionCapacity)
+        val interpreters = ArrayDeque<LiteInterpreter>().apply {
+            add(EncoderStub(attentionCapacity))
+            add(decoder)
+        }
+
+        val summarizer = Summarizer(
+            context,
+            fetcher = fetcher,
+            spFactory = { tokenizer },
+            nativeLoader = { true },
+            interpreterFactory = { interpreters.removeFirst() },
+            logger = { _, _ -> },
+            debug = { }
+        )
+
+        val summary = summarizer.summarize("Input text")
+
+        assertEquals("21,22", summary)
+        assertEquals(decoder.expectedCalls, decoder.callCount)
+
+        summarizer.close()
+    }
+
+    @Test
     fun warmUpReportsFallbackWhenNativeTokenizerMissing() = runBlocking {
         val encFile = File(modelsDir, ModelFetcher.ENCODER_NAME).apply { writeBytes(byteArrayOf()) }
         val decFile = File(modelsDir, ModelFetcher.DECODER_NAME).apply { writeBytes(byteArrayOf()) }
@@ -263,6 +308,75 @@ class SummarizerTest {
         override fun close() {}
 
         private companion object {
+            private const val EOS_ID = 1
+        }
+    }
+
+    private class DecoderWithoutCacheStub(
+        private val tokens: IntArray,
+        private val attentionCapacity: Int,
+        private val hiddenSize: Int = 4
+    ) : LiteInterpreter {
+        override val inputTensorCount: Int = 3
+
+        val expectedCalls: Int = tokens.size + 1
+        var callCount: Int = 0
+            private set
+
+        override fun getOutputTensor(index: Int): LiteTensor = FakeTensor(intArrayOf(1, 1, 1), 1)
+
+        override fun getInputTensor(index: Int): LiteTensor = when (index) {
+            0 -> FakeTensor(intArrayOf(1, attentionCapacity), attentionCapacity)
+            1 -> FakeTensor(intArrayOf(1, attentionCapacity), attentionCapacity)
+            2 -> FakeTensor(intArrayOf(1, attentionCapacity, hiddenSize), attentionCapacity * hiddenSize)
+            else -> FakeTensor()
+        }
+
+        override fun run(input: Any, output: Any) {}
+
+        override fun runForMultipleInputsOutputs(inputs: Array<Any?>, outputs: Map<Int, Any>) {
+            val attentionInput = inputs[0] as Array<IntArray>
+            val tokenInput = inputs[1] as Array<IntArray>
+
+            val expectedLength = (callCount + 1).coerceAtMost(attentionCapacity)
+            check(tokenInput[0][0] == START_TOKEN) {
+                "decoder should receive start token at position 0"
+            }
+            for (i in 1 until expectedLength) {
+                val expected = tokens[i - 1]
+                check(tokenInput[0][i] == expected) {
+                    "decoder token mismatch at position $i on call $callCount"
+                }
+            }
+            for (i in expectedLength until attentionCapacity) {
+                check(tokenInput[0][i] == 0) {
+                    "decoder token input should be zero-padded after position $expectedLength"
+                }
+            }
+
+            for (i in 0 until expectedLength) {
+                check(attentionInput[0][i] == 1) {
+                    "decoder attention mask missing at position $i"
+                }
+            }
+            for (i in expectedLength until attentionCapacity) {
+                check(attentionInput[0][i] == 0) {
+                    "decoder attention mask should be zero after position $expectedLength"
+                }
+            }
+
+            val logits = outputs[0] as Array<Array<FloatArray>>
+            val scores = logits[0][0]
+            scores.fill(0f)
+            val nextToken = if (callCount < tokens.size) tokens[callCount] else EOS_ID
+            scores[nextToken] = 1f
+            callCount++
+        }
+
+        override fun close() {}
+
+        private companion object {
+            private const val START_TOKEN = 0
             private const val EOS_ID = 1
         }
     }


### PR DESCRIPTION
## Summary
- adjust the on-device summarizer to feed the full decoder history when cache tensors are not present so generation no longer degenerates into repeated tokens
- add unit coverage that exercises a decoder without cache inputs to verify the summarizer supplies the expected attention masks and token history

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cad58a8c1c832086502815f4d8299b