### PR TITLE
Add link preview support to notes

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -59,6 +59,19 @@ class EncryptedNoteStore(private val context: Context) {
                     )
                 )
             }
+            val linksJson = obj.optJSONArray("linkPreviews") ?: JSONArray()
+            val linkPreviews = mutableListOf<NoteLinkPreview>()
+            for (j in 0 until linksJson.length()) {
+                val l = linksJson.getJSONObject(j)
+                linkPreviews.add(
+                    NoteLinkPreview(
+                        url = l.getString("url"),
+                        title = l.optString("title", null),
+                        description = l.optString("description", null),
+                        imageUrl = l.optString("imageUrl", null)
+                    )
+                )
+            }
             notes.add(
                 Note(
                     id = obj.getLong("id"),
@@ -67,6 +80,7 @@ class EncryptedNoteStore(private val context: Context) {
                     date = obj.getLong("date"),
                     images = images,
                     files = files,
+                    linkPreviews = linkPreviews,
                     summary = obj.optString("summary", "")
                 )
             )
@@ -94,6 +108,16 @@ class EncryptedNoteStore(private val context: Context) {
                 filesArray.put(fo)
             }
             obj.put("files", filesArray)
+            val linksArray = JSONArray()
+            note.linkPreviews.forEach { link ->
+                val lo = JSONObject()
+                lo.put("url", link.url)
+                link.title?.let { lo.put("title", it) }
+                link.description?.let { lo.put("description", it) }
+                link.imageUrl?.let { lo.put("imageUrl", it) }
+                linksArray.put(lo)
+            }
+            obj.put("linkPreviews", linksArray)
             obj.put("summary", note.summary)
             arr.put(obj)
         }

--- a/app/src/main/java/com/example/starbucknotetaker/LinkPreviewFetcher.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LinkPreviewFetcher.kt
@@ -1,0 +1,152 @@
+package com.example.starbucknotetaker
+
+import java.io.InputStreamReader
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.Locale
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+private const val MAX_HTML_CHARS = 200_000
+
+class LinkPreviewFetcher {
+    private val cache = mutableMapOf<String, LinkPreviewResult>()
+
+    suspend fun fetch(rawUrl: String): LinkPreviewResult {
+        val normalized = normalizeUrl(rawUrl)
+        cache[normalized]?.let { return it }
+        val result = withContext(Dispatchers.IO) {
+            runCatching { loadPreview(normalized) }.getOrElse {
+                LinkPreviewResult.Failure(it.message)
+            }
+        }
+        cache[normalized] = result
+        return result
+    }
+
+    private fun loadPreview(urlString: String): LinkPreviewResult {
+        val url = URL(urlString)
+        val connection = (url.openConnection() as HttpURLConnection).apply {
+            connectTimeout = 10_000
+            readTimeout = 10_000
+            instanceFollowRedirects = true
+            setRequestProperty(
+                "User-Agent",
+                "Mozilla/5.0 (Android) StarbuckNoteTaker/1.0"
+            )
+        }
+        return try {
+            connection.inputStream.use { input ->
+                val reader = InputStreamReader(input, Charsets.UTF_8)
+                val html = reader.readLimited(MAX_HTML_CHARS)
+                val meta = parseMetadata(html, url)
+                val title = meta.title ?: url.host
+                val description = meta.description
+                val imageUrl = meta.imageUrl
+                val preview = NoteLinkPreview(
+                    url = urlString,
+                    title = title,
+                    description = description,
+                    imageUrl = imageUrl
+                )
+                LinkPreviewResult.Success(preview)
+            }
+        } finally {
+            connection.disconnect()
+        }
+    }
+}
+
+private fun InputStreamReader.readLimited(maxChars: Int): String {
+    val builder = StringBuilder()
+    val buffer = CharArray(4096)
+    while (true) {
+        val read = read(buffer)
+        if (read <= 0) break
+        val remaining = maxChars - builder.length
+        if (remaining <= 0) break
+        val toAppend = if (read > remaining) remaining else read
+        builder.append(buffer, 0, toAppend)
+        if (builder.length >= maxChars) break
+    }
+    return builder.toString()
+}
+
+data class ParsedLinkMetadata(
+    val title: String?,
+    val description: String?,
+    val imageUrl: String?,
+)
+
+private fun parseMetadata(html: String, baseUrl: URL): ParsedLinkMetadata {
+    val lowerHtml = html.lowercase(Locale.ROOT)
+    val title = extractTagContent(html, "title")?.cleanWhitespace()
+        ?: extractMetaContent(lowerHtml, html, "property", "og:title")?.cleanWhitespace()
+    val description =
+        extractMetaContent(lowerHtml, html, "property", "og:description")?.cleanWhitespace()
+            ?: extractMetaContent(lowerHtml, html, "name", "description")?.cleanWhitespace()
+    val image = extractMetaContent(lowerHtml, html, "property", "og:image")?.let { resolveUrl(baseUrl, it) }
+    return ParsedLinkMetadata(title, description, image)
+}
+
+private fun extractTagContent(html: String, tag: String): String? {
+    val regex = Regex(
+        pattern = "<${tag}[^>]*>(.*?)</${tag}>",
+        options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL)
+    )
+    val match = regex.find(html) ?: return null
+    return match.groupValues.getOrNull(1)?.cleanWhitespace()
+}
+
+private fun extractMetaContent(
+    lowerHtml: String,
+    originalHtml: String,
+    attribute: String,
+    value: String,
+): String? {
+    val attrRegex = Regex("<meta[^>]*$attribute\\s*=\\s*['\"]?$value['\"]?[^>]*>", RegexOption.IGNORE_CASE)
+    val match = attrRegex.find(lowerHtml) ?: return null
+    val startIndex = match.range.first
+    val endIndex = match.range.last
+    val snippet = originalHtml.substring(startIndex, endIndex + 1)
+    val contentRegex = Regex("content\\s*=\\s*['\"]([^'\"]+)['\"]", RegexOption.IGNORE_CASE)
+    val contentMatch = contentRegex.find(snippet)
+    return contentMatch?.groupValues?.getOrNull(1)
+}
+
+private fun resolveUrl(base: URL, candidate: String): String? {
+    return runCatching { URL(base, candidate).toString() }.getOrNull()
+}
+
+private val schemeRegex = Regex("^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+fun normalizeUrl(raw: String): String {
+    val trimmed = raw.trim()
+    return if (schemeRegex.containsMatchIn(trimmed)) {
+        trimmed
+    } else {
+        "https://$trimmed"
+    }
+}
+
+sealed class LinkPreviewResult {
+    data class Success(val preview: NoteLinkPreview) : LinkPreviewResult()
+    data class Failure(val message: String? = null) : LinkPreviewResult()
+}
+
+fun extractUrls(text: String): List<String> {
+    val matcher = android.util.Patterns.WEB_URL.matcher(text)
+    val results = mutableListOf<String>()
+    while (matcher.find()) {
+        var url = text.substring(matcher.start(), matcher.end())
+        url = url.trimEnd('.', ',', ';', ')', ']', '}', '>', '"', '\'')
+        if (url.isNotBlank()) {
+            results.add(url)
+        }
+    }
+    return results.distinct()
+}
+
+private fun String.cleanWhitespace(): String {
+    return trim().replace(Regex("\\s+"), " ")
+}

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -121,8 +121,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         }
         composable("add") {
             AddNoteScreen(
-                onSave = { title, content, images, files ->
-                    noteViewModel.addNote(title, content, images, files)
+                onSave = { title, content, images, files, linkPreviews ->
+                    noteViewModel.addNote(title, content, images, files, linkPreviews)
                     navController.popBackStack()
                 },
                 onBack = { navController.popBackStack() },
@@ -148,8 +148,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             if (note != null) {
                 EditNoteScreen(
                     note = note,
-                    onSave = { title, content, images, files ->
-                        noteViewModel.updateNote(index, title, content, images, files)
+                    onSave = { title, content, images, files, linkPreviews ->
+                        noteViewModel.updateNote(index, title, content, images, files, linkPreviews)
                         navController.popBackStack()
                     },
                     onCancel = { navController.popBackStack() },

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -10,6 +10,7 @@ data class Note(
     val date: Long = System.currentTimeMillis(),
     val images: List<String> = emptyList(),
     val files: List<NoteFile> = emptyList(),
+    val linkPreviews: List<NoteLinkPreview> = emptyList(),
     val summary: String = "",
 )
 
@@ -22,5 +23,15 @@ data class NoteFile(
     val name: String,
     val mime: String,
     val data: String,
+)
+
+/**
+ * Metadata describing a rich preview for a URL embedded in a note.
+ */
+data class NoteLinkPreview(
+    val url: String,
+    val title: String? = null,
+    val description: String? = null,
+    val imageUrl: String? = null,
 )
 

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -64,7 +64,13 @@ class NoteViewModel : ViewModel() {
         }
     }
 
-    fun addNote(title: String?, content: String, images: List<Pair<Uri, Int>>, files: List<Uri>) {
+    fun addNote(
+        title: String?,
+        content: String,
+        images: List<Pair<Uri, Int>>,
+        files: List<Uri>,
+        linkPreviews: List<NoteLinkPreview>
+    ) {
         val finalTitle = if (title.isNullOrBlank()) {
             "Untitled ${untitledCounter++}"
         } else {
@@ -138,6 +144,7 @@ class NoteViewModel : ViewModel() {
             date = System.currentTimeMillis(),
             images = embeddedImages,
             files = embeddedFiles,
+            linkPreviews = linkPreviews,
             summary = summarizer?.let { it.fallbackSummary(finalContent) } ?: finalContent.take(200)
         )
         _notes.add(0, note) // newest first
@@ -158,7 +165,14 @@ class NoteViewModel : ViewModel() {
         }
     }
 
-    fun updateNote(index: Int, title: String?, content: String, images: List<String>, files: List<NoteFile>) {
+    fun updateNote(
+        index: Int,
+        title: String?,
+        content: String,
+        images: List<String>,
+        files: List<NoteFile>,
+        linkPreviews: List<NoteLinkPreview>
+    ) {
         if (index in _notes.indices) {
             val note = _notes[index]
             val finalTitle = if (title.isNullOrBlank()) note.title else title
@@ -167,6 +181,7 @@ class NoteViewModel : ViewModel() {
                 content = content.trim(),
                 images = images,
                 files = files,
+                linkPreviews = linkPreviews,
                 summary = summarizer?.let { it.fallbackSummary(content) } ?: content.take(200)
             )
             _notes[index] = updated

--- a/app/src/main/java/com/example/starbucknotetaker/ui/LinkPreviewCard.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/LinkPreviewCard.kt
@@ -1,0 +1,124 @@
+package com.example.starbucknotetaker.ui
+
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Card
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberAsyncImagePainter
+import com.example.starbucknotetaker.NoteLinkPreview
+
+@Composable
+fun LinkPreviewCard(
+    preview: NoteLinkPreview,
+    isLoading: Boolean,
+    errorMessage: String?,
+    onRemove: (() -> Unit)? = null,
+    onOpen: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    val host = remember(preview.url) {
+        runCatching { Uri.parse(preview.url).host ?: preview.url }
+            .getOrDefault(preview.url)
+    }
+    Card(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+            .let { base -> if (onOpen != null) base.clickable(onClick = onOpen) else base },
+        shape = RoundedCornerShape(12.dp),
+        elevation = 4.dp,
+    ) {
+        Box(modifier = Modifier.background(MaterialTheme.colors.surface)) {
+            Column(modifier = Modifier.padding(12.dp)) {
+                when {
+                    isLoading -> {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            CircularProgressIndicator(modifier = Modifier.size(20.dp), strokeWidth = 2.dp)
+                            Spacer(modifier = Modifier.size(8.dp))
+                            Text(text = "Loading preview…")
+                        }
+                    }
+                    errorMessage != null -> {
+                        Text(text = errorMessage, color = MaterialTheme.colors.error)
+                    }
+                    else -> {
+                        preview.imageUrl?.let { imageUrl ->
+                            Image(
+                                painter = rememberAsyncImagePainter(imageUrl),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(160.dp)
+                                    .clip(RoundedCornerShape(8.dp)),
+                                contentScale = ContentScale.Crop,
+                            )
+                            Spacer(modifier = Modifier.height(8.dp))
+                        }
+                        preview.title?.takeIf { it.isNotBlank() }?.let { title ->
+                            Text(
+                                text = title,
+                                style = MaterialTheme.typography.subtitle1,
+                                maxLines = 2,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                        preview.description?.takeIf { it.isNotBlank() }?.let { description ->
+                            Text(
+                                text = description,
+                                style = MaterialTheme.typography.body2,
+                                maxLines = 3,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                        }
+                        Text(
+                            text = host,
+                            style = MaterialTheme.typography.caption,
+                            color = Color.Gray,
+                        )
+                    }
+                }
+            }
+            if (onRemove != null) {
+                IconButton(
+                    onClick = onRemove,
+                    modifier = Modifier.align(Alignment.TopEnd)
+                ) {
+                    Icon(Icons.Default.Close, contentDescription = "Remove preview")
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -70,6 +70,7 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
                 val trimmed = line.trim()
                 val imagePlaceholder = Regex("\\[\\[image:(\\d+)]]").matchEntire(trimmed)
                 val filePlaceholder = Regex("\\[\\[file:(\\d+)]]").matchEntire(trimmed)
+                val linkPlaceholder = Regex("\\[\\[link:(\\d+)]]").matchEntire(trimmed)
                 when {
                     imagePlaceholder != null -> {
                         val index = imagePlaceholder.groupValues[1].toInt()
@@ -110,6 +111,21 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
                                 Spacer(modifier = Modifier.width(8.dp))
                                 Text(file.name)
                             }
+                        }
+                    }
+                    linkPlaceholder != null -> {
+                        val index = linkPlaceholder.groupValues[1].toInt()
+                        note.linkPreviews.getOrNull(index)?.let { preview ->
+                            LinkPreviewCard(
+                                preview = preview,
+                                isLoading = false,
+                                errorMessage = null,
+                                onOpen = {
+                                    runCatching {
+                                        context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(preview.url)))
+                                    }
+                                }
+                            )
                         }
                     }
                     else -> {

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -38,7 +38,7 @@ class NoteViewModelTest {
         val viewModel = NoteViewModel()
         setField(viewModel, "summarizer", summarizer)
 
-        viewModel.addNote("Title", "Content", emptyList(), emptyList())
+        viewModel.addNote("Title", "Content", emptyList(), emptyList(), emptyList())
 
         advanceUntilIdle()
 


### PR DESCRIPTION
## Summary
- add NoteLinkPreview models and encrypted store serialization to persist link preview metadata with notes
- introduce LinkPreviewFetcher plus link preview composable and integrate URL detection into add/edit note flows
- surface saved previews in note detail UI and thread preview collections through view model, navigation, and tests

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cbef2dfbf083208cfb43558cc056f3