### PR TITLE
Delay URL previews until link completion

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/LinkPreviewCard.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/LinkPreviewCard.kt
@@ -37,6 +37,7 @@ import com.example.starbucknotetaker.NoteLinkPreview
 @Composable
 fun LinkPreviewCard(
     preview: NoteLinkPreview,
+    awaitingCompletion: Boolean,
     isLoading: Boolean,
     errorMessage: String?,
     onRemove: (() -> Unit)? = null,
@@ -58,6 +59,15 @@ fun LinkPreviewCard(
         Box(modifier = Modifier.background(MaterialTheme.colors.surface)) {
             Column(modifier = Modifier.padding(12.dp)) {
                 when {
+                    awaitingCompletion -> {
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            Text(text = "URL detected. Waiting for link completion...")
+                        }
+                    }
                     isLoading -> {
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -118,6 +118,7 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
                         note.linkPreviews.getOrNull(index)?.let { preview ->
                             LinkPreviewCard(
                                 preview = preview,
+                                awaitingCompletion = false,
                                 isLoading = false,
                                 errorMessage = null,
                                 onOpen = {


### PR DESCRIPTION
## Summary
- show a placeholder while a URL is still being typed and only fetch a preview once the link is completed or the note is submitted
- track link preview state in the add and edit flows so that placeholders become previews and can be dismissed reliably
- generate preview images from a live page snapshot using the WordPress mShots service

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cd59ab11a88320aa22df8041781e3e