### PR TITLE
Fix import PIN entry behavior

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -212,18 +212,21 @@ class NoteViewModel : ViewModel() {
         }
     }
 
-    fun importNotes(context: Context, uri: Uri, archivePin: String, overwrite: Boolean) {
-        try {
-            context.contentResolver.openInputStream(uri)?.use { input ->
-                val bytes = input.readBytes()
-                val imported = EncryptedNoteStore(context).loadNotesFromBytes(bytes, archivePin)
-                if (overwrite) {
-                    _notes.clear()
-                }
-                _notes.addAll(imported)
-                pin?.let { store?.saveNotes(_notes, it) }
+    fun importNotes(context: Context, uri: Uri, archivePin: String, overwrite: Boolean): Boolean {
+        return try {
+            val bytes = context.contentResolver.openInputStream(uri)?.use { input ->
+                input.readBytes()
+            } ?: return false
+            val imported = EncryptedNoteStore(context).loadNotesFromBytes(bytes, archivePin)
+            if (overwrite) {
+                _notes.clear()
             }
-        } catch (_: Exception) {}
+            _notes.addAll(imported)
+            pin?.let { store?.saveNotes(_notes, it) }
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     override fun onCleared() {


### PR DESCRIPTION
## Summary
- mask the import PIN entry with password dots and surface validation errors
- keep the import dialog open until an import succeeds so users can retry on failure
- return a success signal from the import workflow so the UI can react accordingly

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cd5ff9d5208320b47545fe2e9e1f86