### PR TITLE
Ensure canceling edit navigates immediately

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -313,14 +313,14 @@ fun EditNoteScreen(
                 title = { Text("Edit Note") },
                 navigationIcon = {
                     IconButton(onClick = {
+                        hideKeyboard()
+                        focusManager.clearFocus(force = true)
+                        onCancel()
                         scope.launch {
-                            hideKeyboard()
-                            focusManager.clearFocus(force = true)
                             scaffoldState.snackbarHostState.showSnackbar(
                                 "Changes discarded",
                                 duration = SnackbarDuration.Short
                             )
-                            onCancel()
                         }
                     }) {
                         Icon(Icons.Default.Close, contentDescription = "Discard")


### PR DESCRIPTION
## Summary
- trigger the cancel action before launching the snackbar so the screen closes without delay

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd619f61bc8320bdfde95f8c079dad