### PR TITLE
Add calendar event support with event-aware note creation and display

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -72,6 +72,17 @@ class EncryptedNoteStore(private val context: Context) {
                     )
                 )
             }
+            val eventObj = obj.optJSONObject("event")
+            val event = eventObj?.let {
+                NoteEvent(
+                    start = it.getLong("start"),
+                    end = it.getLong("end"),
+                    allDay = it.optBoolean("allDay", false),
+                    timeZone = it.optString("timeZone", java.util.TimeZone.getDefault().id),
+                    location = it.optString("location", null)
+                        ?.takeIf { location -> location.isNotBlank() }
+                )
+            }
             notes.add(
                 Note(
                     id = obj.getLong("id"),
@@ -81,7 +92,8 @@ class EncryptedNoteStore(private val context: Context) {
                     images = images,
                     files = files,
                     linkPreviews = linkPreviews,
-                    summary = obj.optString("summary", "")
+                    summary = obj.optString("summary", ""),
+                    event = event,
                 )
             )
         }
@@ -119,6 +131,15 @@ class EncryptedNoteStore(private val context: Context) {
             }
             obj.put("linkPreviews", linksArray)
             obj.put("summary", note.summary)
+            note.event?.let { event ->
+                val eo = JSONObject()
+                eo.put("start", event.start)
+                eo.put("end", event.end)
+                eo.put("allDay", event.allDay)
+                eo.put("timeZone", event.timeZone)
+                event.location?.let { eo.put("location", it) }
+                obj.put("event", eo)
+            }
             arr.put(obj)
         }
         val root = JSONObject().apply {

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -16,6 +16,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.starbucknotetaker.ui.AddNoteScreen
+import com.example.starbucknotetaker.ui.NoteEntryMode
 import com.example.starbucknotetaker.ui.NoteDetailScreen
 import com.example.starbucknotetaker.ui.NoteListScreen
 import com.example.starbucknotetaker.ui.PinEnterScreen
@@ -113,6 +114,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             NoteListScreen(
                 notes = noteViewModel.notes,
                 onAddNote = { navController.navigate("add") },
+                onAddEvent = { navController.navigate("add_event") },
                 onOpenNote = { index -> navController.navigate("detail/$index") },
                 onDeleteNote = { index -> noteViewModel.deleteNote(index) },
                 onSettings = { navController.navigate("settings") },
@@ -121,14 +123,30 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         }
         composable("add") {
             AddNoteScreen(
-                onSave = { title, content, images, files, linkPreviews ->
-                    noteViewModel.addNote(title, content, images, files, linkPreviews)
+                onSave = { title, content, images, files, linkPreviews, event ->
+                    noteViewModel.addNote(title, content, images, files, linkPreviews, event)
                     navController.popBackStack()
                 },
                 onBack = { navController.popBackStack() },
                 onDisablePinCheck = { pinCheckEnabled = false },
                 onEnablePinCheck = { pinCheckEnabled = true },
-                summarizerState = summarizerState
+                summarizerState = summarizerState,
+                entryMode = NoteEntryMode.Note,
+            )
+        }
+        composable("add_event") {
+            AddNoteScreen(
+                onSave = { title, content, images, files, linkPreviews, event ->
+                    if (event != null) {
+                        noteViewModel.addNote(title, content, images, files, linkPreviews, event)
+                    }
+                    navController.popBackStack()
+                },
+                onBack = { navController.popBackStack() },
+                onDisablePinCheck = { pinCheckEnabled = false },
+                onEnablePinCheck = { pinCheckEnabled = true },
+                summarizerState = summarizerState,
+                entryMode = NoteEntryMode.Event,
             )
         }
         composable("detail/{index}") { backStackEntry ->
@@ -148,8 +166,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
             if (note != null) {
                 EditNoteScreen(
                     note = note,
-                    onSave = { title, content, images, files, linkPreviews ->
-                        noteViewModel.updateNote(index, title, content, images, files, linkPreviews)
+                    onSave = { title, content, images, files, linkPreviews, event ->
+                        noteViewModel.updateNote(index, title, content, images, files, linkPreviews, event)
                         navController.popBackStack()
                     },
                     onCancel = { navController.popBackStack() },

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -12,6 +12,7 @@ data class Note(
     val files: List<NoteFile> = emptyList(),
     val linkPreviews: List<NoteLinkPreview> = emptyList(),
     val summary: String = "",
+    val event: NoteEvent? = null,
 )
 
 /**
@@ -33,5 +34,16 @@ data class NoteLinkPreview(
     val title: String? = null,
     val description: String? = null,
     val imageUrl: String? = null,
+)
+
+/**
+ * Metadata describing an associated calendar event for a note entry.
+ */
+data class NoteEvent(
+    val start: Long,
+    val end: Long,
+    val allDay: Boolean,
+    val timeZone: String,
+    val location: String? = null,
 )
 


### PR DESCRIPTION
## Summary
- extend the note model, encrypted storage, and view-model summarization pipeline to persist optional calendar event metadata
- upgrade note creation, editing, and list/detail UI flows so users can pick between notes and events, capture event date/time/location, and see event details in the list and reader views
- add navigation for the new event workflow while preserving existing attachment/link preview tooling for both notes and events

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cd6a0028048320a6e9842e2f7a569b