### PR TITLE
Improve summarizer output coherence

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -10,6 +10,7 @@ import java.io.File
 import java.io.RandomAccessFile
 import java.nio.MappedByteBuffer
 import java.nio.channels.FileChannel
+import java.util.LinkedHashMap
 import java.util.Locale
 
 /**
@@ -431,7 +432,90 @@ class Summarizer(
             }
             cleanedWords.add(word)
         }
-        return cleanedWords.joinToString(" ")
+
+        if (cleanedWords.isEmpty()) return ""
+        val collapsed = cleanedWords.joinToString(" ").trim()
+        if (collapsed.isEmpty()) return ""
+
+        val stopWordCount = cleanedWords.count { STOP_WORDS.contains(normalizeWord(it)) }
+        val hasSentencePunctuation = collapsed.any { it == '.' || it == '!' || it == '?' }
+        if (hasSentencePunctuation || stopWordCount > 0) {
+            return collapsed
+        }
+
+        val rewritten = buildKeywordSentence(cleanedWords)
+        if (rewritten.isNotEmpty()) return rewritten
+
+        return collapsed
+    }
+
+    private fun buildKeywordSentence(words: List<String>): String {
+        if (words.isEmpty()) return ""
+
+        val keywords = LinkedHashMap<String, String>()
+        for (word in words) {
+            val trimmed = trimEdgePunctuation(word)
+            val normalized = normalizeWord(trimmed)
+            if (normalized.isEmpty() || STOP_WORDS.contains(normalized)) continue
+            keywords.putIfAbsent(normalized, trimmed)
+        }
+
+        var candidates = keywords.values.toList()
+        if (candidates.isEmpty()) {
+            candidates = words.map { trimEdgePunctuation(it) }.filter { it.isNotEmpty() }
+        }
+
+        if (candidates.isEmpty()) return ""
+
+        val limited = candidates.take(MAX_KEYWORD_SENTENCE_WORDS)
+        val formattedKeywords = limited.mapNotNull { formatKeyword(it) }
+        if (formattedKeywords.isEmpty()) return ""
+
+        val prefix = if (formattedKeywords.size == 1) {
+            "Summary focuses on "
+        } else {
+            "Summary highlights "
+        }
+        val sentenceBody = formatWordList(formattedKeywords)
+        return ensureSentence(prefix + sentenceBody)
+    }
+
+    private fun trimEdgePunctuation(word: String): String {
+        var start = 0
+        var end = word.length
+        while (start < end && WORD_TRIM_CHARACTERS.contains(word[start])) start++
+        while (end > start && WORD_TRIM_CHARACTERS.contains(word[end - 1])) end--
+        return word.substring(start, end).trim()
+    }
+
+    private fun formatKeyword(word: String): String? {
+        if (word.isEmpty()) return null
+        val cleaned = word.trim()
+        if (cleaned.isEmpty()) return null
+        val hasUppercase = cleaned.any { it.isUpperCase() }
+        val hasLowercase = cleaned.any { it.isLowerCase() }
+        val normalized = when {
+            hasUppercase && !hasLowercase -> cleaned
+            else -> cleaned.lowercase(Locale.US)
+        }
+        return normalized
+    }
+
+    private fun formatWordList(words: List<String>): String {
+        if (words.isEmpty()) return ""
+        if (words.size == 1) return words[0]
+        if (words.size == 2) return "${words[0]} and ${words[1]}"
+        val head = words.dropLast(1).joinToString(", ")
+        return "$head, and ${words.last()}"
+    }
+
+    private fun ensureSentence(text: String): String {
+        val trimmed = text.trim()
+        if (trimmed.isEmpty()) return ""
+        val capitalized = trimmed.replaceFirstChar { ch ->
+            if (ch.isLowerCase()) ch.titlecase(Locale.US) else ch.toString()
+        }
+        return if (capitalized.last() in SENTENCE_ENDINGS) capitalized else "$capitalized."
     }
 
     private fun buildKeywordStats(text: String): KeywordStats {
@@ -648,5 +732,10 @@ class Summarizer(
             "will",
             "just"
         )
+        private val WORD_TRIM_CHARACTERS = setOf(
+            ',', '.', ';', ':', '-', '–', '—', '"', '\'', '(', ')', '[', ']', '{', '}', '/', '\\'
+        )
+        private val SENTENCE_ENDINGS = charArrayOf('.', '!', '?')
+        private const val MAX_KEYWORD_SENTENCE_WORDS = 6
     }
 }


### PR DESCRIPTION
## Summary
- enhance `Summarizer.cleanSummary` to detect outputs that lack punctuation or stop words and rewrite them into concise sentences using extracted keywords
- add helper utilities for trimming punctuation, formatting keyword lists, and ensuring sentence capitalization/punctuation
- expand unit coverage to validate the new behavior and adjust expectations for deterministic decoder tests

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68cd7dd2c23c83208ad058c228ea10bf