### PR TITLE
Update note timestamps when edited

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -115,8 +115,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 notes = noteViewModel.notes,
                 onAddNote = { navController.navigate("add") },
                 onAddEvent = { navController.navigate("add_event") },
-                onOpenNote = { index -> navController.navigate("detail/$index") },
-                onDeleteNote = { index -> noteViewModel.deleteNote(index) },
+                onOpenNote = { noteId -> navController.navigate("detail/$noteId") },
+                onDeleteNote = { noteId -> noteViewModel.deleteNote(noteId) },
                 onSettings = { navController.navigate("settings") },
                 summarizerState = summarizerState
             )
@@ -149,25 +149,27 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 entryMode = NoteEntryMode.Event,
             )
         }
-        composable("detail/{index}") { backStackEntry ->
-            val index = backStackEntry.arguments?.getString("index")?.toIntOrNull() ?: 0
-            val note = noteViewModel.notes.getOrNull(index)
+        composable("detail/{noteId}") { backStackEntry ->
+            val noteId = backStackEntry.arguments?.getString("noteId")?.toLongOrNull()
+            val note = noteId?.let { noteViewModel.getNoteById(it) }
             if (note != null) {
                 NoteDetailScreen(
                     note = note,
                     onBack = { navController.popBackStack() },
-                    onEdit = { navController.navigate("edit/$index") }
+                    onEdit = { navController.navigate("edit/$noteId") }
                 )
+            } else {
+                navController.popBackStack()
             }
         }
-        composable("edit/{index}") { backStackEntry ->
-            val index = backStackEntry.arguments?.getString("index")?.toIntOrNull() ?: 0
-            val note = noteViewModel.notes.getOrNull(index)
-            if (note != null) {
+        composable("edit/{noteId}") { backStackEntry ->
+            val noteId = backStackEntry.arguments?.getString("noteId")?.toLongOrNull()
+            val note = noteId?.let { noteViewModel.getNoteById(it) }
+            if (note != null && noteId != null) {
                 EditNoteScreen(
                     note = note,
                     onSave = { title, content, images, files, linkPreviews, event ->
-                        noteViewModel.updateNote(index, title, content, images, files, linkPreviews, event)
+                        noteViewModel.updateNote(noteId, title, content, images, files, linkPreviews, event)
                         navController.popBackStack()
                     },
                     onCancel = { navController.popBackStack() },
@@ -175,6 +177,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                     onEnablePinCheck = { pinCheckEnabled = true },
                     summarizerState = summarizerState
                 )
+            } else {
+                navController.popBackStack()
             }
         }
         composable("settings") {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -41,8 +41,8 @@ fun NoteListScreen(
     notes: List<Note>,
     onAddNote: () -> Unit,
     onAddEvent: () -> Unit,
-    onOpenNote: (Int) -> Unit,
-    onDeleteNote: (Int) -> Unit,
+    onOpenNote: (Long) -> Unit,
+    onDeleteNote: (Long) -> Unit,
     onSettings: () -> Unit,
     summarizerState: Summarizer.SummarizerState
 ) {
@@ -53,7 +53,7 @@ fun NoteListScreen(
                 it.summary.contains(query, true) ||
                 (it.event?.location?.contains(query, true) ?: false)
     }
-    var openIndex by remember { mutableStateOf<Int?>(null) }
+    var openNoteId by remember { mutableStateOf<Long?>(null) }
     val focusManager = LocalFocusManager.current
     val hideKeyboard = rememberKeyboardHider()
     var creationMenuExpanded by remember { mutableStateOf(false) }
@@ -135,24 +135,23 @@ fun NoteListScreen(
             )
             LazyColumn(modifier = Modifier.fillMaxSize()) {
                 itemsIndexed(filtered, key = { _, note -> note.id }) { index, note ->
-                    val originalIndex = notes.indexOf(note)
                     val showDate = index == 0 || !isSameDay(filtered[index - 1].date, note.date)
                     if (showDate) {
                         DateHeader(note.date)
                     }
                     SwipeToDeleteNoteItem(
                         note = note,
-                        isOpen = openIndex == originalIndex,
-                        onOpen = { openIndex = originalIndex },
-                        onClose = { if (openIndex == originalIndex) openIndex = null },
+                        isOpen = openNoteId == note.id,
+                        onOpen = { openNoteId = note.id },
+                        onClose = { if (openNoteId == note.id) openNoteId = null },
                         onClick = {
                             hideKeyboard()
                             focusManager.clearFocus(force = true)
-                            onOpenNote(originalIndex)
+                            onOpenNote(note.id)
                         },
                         onDelete = {
-                            onDeleteNote(originalIndex)
-                            if (openIndex == originalIndex) openIndex = null
+                            onDeleteNote(note.id)
+                            if (openNoteId == note.id) openNoteId = null
                         }
                     )
                 }


### PR DESCRIPTION
## Summary
- update the note view model to refresh timestamps on edits, sort by date, and expose id-based lookups
- route note list interactions and navigation through note ids so entries remain consistent after reordering

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cdac345a48832094c270096a0ba31b