### PR TITLE
Allow keyword-style headlines without rewriting

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -95,7 +95,7 @@ class SummarizerTest {
 
         val summary = summarizer.summarize("Input text")
 
-        assertEquals("Summary focuses on 21,22.", summary)
+        assertEquals("21,22.", summary)
         assertEquals(decoder.expectedCalls, decoder.callCount)
         assertFalse("decoder should not run after EOS", decoder.extraInvocation)
 
@@ -277,7 +277,7 @@ class SummarizerTest {
         val summary = summarizer.summarize(input)
 
         assertEquals(
-            "Summary highlights timeline, milestones, roadmap, deliverables, and updates.",
+            "Timeline milestones roadmap deliverables updates",
             summary
         )
         assertEquals(Summarizer.SummarizerState.Ready, summarizer.state.value)
@@ -465,7 +465,7 @@ class SummarizerTest {
 
         val summary = summarizer.summarize("Input text")
 
-        assertEquals("Summary focuses on 21,22.", summary)
+        assertEquals("21,22.", summary)
         assertEquals(decoder.expectedCalls, decoder.callCount)
 
         summarizer.close()


### PR DESCRIPTION
## Summary
- allow keyword-only generations to pass through cleanSummary when they look like concise keyword lists
- drop the "Summary highlights" prefix when rewriting keyword sentences to keep results headline-style
- update unit tests to cover keyword-style outputs and new formatting

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cdb6f725dc832088bcf13bbaeaa8b8