### PR TITLE
Simplify keyword summaries

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -275,11 +275,10 @@ class SummarizerTest {
 
         val input = "Project planning notes covering roadmap milestones"
         val summary = summarizer.summarize(input)
+        val expected = listOf(400, 401, 402, 403, 404).joinToString(" ") { tokenMap[it] ?: "" }
 
-        assertEquals(
-            "Timeline milestones roadmap deliverables updates",
-            summary
-        )
+        assertEquals(expected, summary)
+        assertFalse(summary.startsWith("Summary highlights", ignoreCase = true))
         assertEquals(Summarizer.SummarizerState.Ready, summarizer.state.value)
 
         summarizer.close()


### PR DESCRIPTION
## Summary
- return collapsed keyword-style summaries instead of rebuilding sentences when punctuation or stop words are absent
- remove the keyword sentence rewriting helpers and add a simple sentence casing path for non-letter output
- update tests to assert that decoder keyword lists surface without any "Summary highlights" prefix

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cdc232e50c8320b45db1bd47486cc3