### PR TITLE
Add per-note PIN locking and update note list UI

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -96,6 +96,7 @@ class EncryptedNoteStore(private val context: Context) {
                     linkPreviews = linkPreviews,
                     summary = obj.optString("summary", ""),
                     event = event,
+                    isLocked = obj.optBoolean("locked", false),
                 )
             )
         }
@@ -143,6 +144,7 @@ class EncryptedNoteStore(private val context: Context) {
                 event.location?.let { eo.put("location", it) }
                 obj.put("event", eo)
             }
+            obj.put("locked", note.isLocked)
             arr.put(obj)
         }
         val root = JSONObject().apply {

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -13,6 +13,7 @@ data class Note(
     val linkPreviews: List<NoteLinkPreview> = emptyList(),
     val summary: String = "",
     val event: NoteEvent? = null,
+    val isLocked: Boolean = false,
 )
 
 /**

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material.icons.filled.LockOpen
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.runtime.*
@@ -45,7 +47,13 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 
 @Composable
-fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
+fun NoteDetailScreen(
+    note: Note,
+    onBack: () -> Unit,
+    onEdit: () -> Unit,
+    onLockRequest: () -> Unit,
+    onUnlockRequest: () -> Unit,
+) {
     val context = LocalContext.current
     var fullImage by remember { mutableStateOf<String?>(null) }
     Scaffold(topBar = {
@@ -60,6 +68,20 @@ fun NoteDetailScreen(note: Note, onBack: () -> Unit, onEdit: () -> Unit) {
                 }
             },
             actions = {
+                IconButton(
+                    onClick = {
+                        if (note.isLocked) {
+                            onUnlockRequest()
+                        } else {
+                            onLockRequest()
+                        }
+                    }
+                ) {
+                    Icon(
+                        imageVector = if (note.isLocked) Icons.Default.LockOpen else Icons.Default.Lock,
+                        contentDescription = if (note.isLocked) "Unlock note" else "Lock note"
+                    )
+                }
                 IconButton(onClick = onEdit) {
                     Icon(Icons.Default.Edit, contentDescription = "Edit")
                 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -14,8 +14,10 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.NoteAdd
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Event
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.runtime.*
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -41,7 +43,7 @@ fun NoteListScreen(
     notes: List<Note>,
     onAddNote: () -> Unit,
     onAddEvent: () -> Unit,
-    onOpenNote: (Long) -> Unit,
+    onOpenNote: (Note) -> Unit,
     onDeleteNote: (Long) -> Unit,
     onSettings: () -> Unit,
     summarizerState: Summarizer.SummarizerState
@@ -147,7 +149,7 @@ fun NoteListScreen(
                         onClick = {
                             hideKeyboard()
                             focusManager.clearFocus(force = true)
-                            onOpenNote(note.id)
+                            onOpenNote(note)
                         },
                         onDelete = {
                             onDeleteNote(note.id)
@@ -272,11 +274,48 @@ fun NoteListItem(note: Note, onClick: () -> Unit, modifier: Modifier = Modifier)
             }
         }
         if (note.summary.isNotBlank()) {
-            Text(
-                text = note.summary,
-                maxLines = 2,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(top = 2.dp)
+            if (note.isLocked) {
+                LockedSummaryPlaceholder(modifier = Modifier.padding(top = 2.dp))
+            } else {
+                Text(
+                    text = note.summary,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun LockedSummaryPlaceholder(modifier: Modifier = Modifier) {
+    val barColor = MaterialTheme.colors.onSurface.copy(alpha = 0.15f)
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            imageVector = Icons.Default.Lock,
+            contentDescription = null,
+            tint = MaterialTheme.colors.onSurface.copy(alpha = 0.6f)
+        )
+        Spacer(modifier = Modifier.width(8.dp))
+        Column(
+            verticalArrangement = Arrangement.spacedBy(4.dp),
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.85f)
+                    .height(8.dp)
+                    .background(barColor, shape = RoundedCornerShape(4.dp))
+            )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth(0.65f)
+                    .height(8.dp)
+                    .background(barColor, shape = RoundedCornerShape(4.dp))
             )
         }
     }


### PR DESCRIPTION
## Summary
- add a per-note lock flag and persist it with encrypted storage
- prompt for the PIN when opening locked entries and allow locking/unlocking directly from the detail screen
- mask locked notes in the list with a padlock placeholder so previews stay hidden

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68cea839a8d08320b04f18fee6d65e57