### PR TITLE
Keep screen on during audio transcription

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AudioTranscriptionDialog.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AudioTranscriptionDialog.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
@@ -45,6 +46,19 @@ fun AudioTranscriptionDialog(
     var rms by remember { mutableStateOf(0f) }
     var partialText by remember { mutableStateOf("") }
     var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    val dialogView = LocalView.current
+    val shouldKeepScreenOn = isRecording || awaitingResult
+    DisposableEffect(dialogView, shouldKeepScreenOn) {
+        if (shouldKeepScreenOn) {
+            dialogView.keepScreenOn = true
+        }
+        onDispose {
+            if (shouldKeepScreenOn) {
+                dialogView.keepScreenOn = false
+            }
+        }
+    }
 
     DisposableEffect(speechRecognizer) {
         val listener = object : RecognitionListener {


### PR DESCRIPTION
## Summary
- keep the device screen awake while audio transcription is recording or awaiting results by toggling the dialog view's keepScreenOn flag

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ceb9f363a88320978eb2be7e13e89b