### PR TITLE
Improve transcription flow, locking, and PIN management

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -55,11 +55,21 @@ class NoteViewModel : ViewModel() {
                     this@NoteViewModel.context?.let { ctx ->
                         when (state) {
                             Summarizer.SummarizerState.Ready ->
-                                Toast.makeText(ctx, "AI summarizer loaded", Toast.LENGTH_SHORT).show()
+                                NotificationInterruptionManager.runOrQueue {
+                                    Toast.makeText(ctx, "AI summarizer loaded", Toast.LENGTH_SHORT).show()
+                                }
                             Summarizer.SummarizerState.Fallback ->
-                                Toast.makeText(ctx, "Using fallback summarization", Toast.LENGTH_SHORT).show()
+                                NotificationInterruptionManager.runOrQueue {
+                                    Toast.makeText(ctx, "Using fallback summarization", Toast.LENGTH_SHORT).show()
+                                }
                             is Summarizer.SummarizerState.Error ->
-                                Toast.makeText(ctx, "Summarizer init failed: ${'$'}{state.message}", Toast.LENGTH_LONG).show()
+                                NotificationInterruptionManager.runOrQueue {
+                                    Toast.makeText(
+                                        ctx,
+                                        "Summarizer init failed: ${'$'}{state.message}",
+                                        Toast.LENGTH_LONG
+                                    ).show()
+                                }
                             else -> {}
                         }
                     }
@@ -196,6 +206,11 @@ class NoteViewModel : ViewModel() {
             }
             pin?.let { store?.saveNotes(_notes, it) }
         }
+    }
+
+    fun updateStoredPin(newPin: String) {
+        pin = newPin
+        pin?.let { store?.saveNotes(_notes, it) }
     }
 
     private fun processNewNoteContent(

--- a/app/src/main/java/com/example/starbucknotetaker/NotificationInterruptionManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NotificationInterruptionManager.kt
@@ -1,0 +1,47 @@
+package com.example.starbucknotetaker
+
+import java.util.ArrayDeque
+import java.util.Deque
+
+/**
+ * Coordinates temporary suppression of transient UI notifications (such as Toasts)
+ * while sensitive interactions are in progress.
+ */
+object NotificationInterruptionManager {
+    private val pendingCallbacks: Deque<() -> Unit> = ArrayDeque()
+    private var blockCount: Int = 0
+
+    @Synchronized
+    fun blockNotifications() {
+        blockCount += 1
+    }
+
+    @Synchronized
+    fun releaseNotifications(): List<() -> Unit> {
+        if (blockCount > 0) {
+            blockCount -= 1
+        }
+        if (blockCount == 0 && pendingCallbacks.isNotEmpty()) {
+            val callbacks = mutableListOf<() -> Unit>()
+            while (pendingCallbacks.isNotEmpty()) {
+                callbacks.add(pendingCallbacks.removeFirst())
+            }
+            return callbacks
+        }
+        return emptyList()
+    }
+
+    fun runOrQueue(callback: () -> Unit) {
+        val shouldQueue = synchronized(this) {
+            if (blockCount > 0) {
+                pendingCallbacks.addLast(callback)
+                true
+            } else {
+                false
+            }
+        }
+        if (!shouldQueue) {
+            callback()
+        }
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -15,17 +15,20 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
+import com.example.starbucknotetaker.PinManager
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
 @Composable
 fun SettingsScreen(
+    pinManager: PinManager,
     onBack: () -> Unit,
     onImport: (Uri, String, Boolean) -> Boolean,
     onExport: (Uri) -> Unit,
     onDisablePinCheck: () -> Unit,
-    onEnablePinCheck: () -> Unit
+    onEnablePinCheck: () -> Unit,
+    onPinChanged: (String) -> Unit
 ) {
     var showDialog by remember { mutableStateOf(false) }
     var selectedUri by remember { mutableStateOf<Uri?>(null) }
@@ -48,6 +51,13 @@ fun SettingsScreen(
         }
         onEnablePinCheck()
     }
+
+    var currentPin by remember { mutableStateOf("") }
+    var newPin by remember { mutableStateOf("") }
+    var confirmPin by remember { mutableStateOf("") }
+    var currentPinVerified by remember { mutableStateOf(false) }
+    var pinChangeError by remember { mutableStateOf<String?>(null) }
+    var pinChangeMessage by remember { mutableStateOf<String?>(null) }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -172,6 +182,125 @@ fun SettingsScreen(
                 exportLauncher.launch(name)
             }) {
                 Text("Export archived notes file")
+            }
+            Divider()
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                Text("Change PIN", style = MaterialTheme.typography.h6)
+                OutlinedTextField(
+                    value = currentPin,
+                    onValueChange = { input ->
+                        if (input.length <= 6 && input.all { it.isDigit() }) {
+                            currentPin = input
+                            pinChangeError = null
+                            pinChangeMessage = null
+                            if (currentPinVerified) {
+                                currentPinVerified = false
+                                newPin = ""
+                                confirmPin = ""
+                            }
+                        }
+                    },
+                    label = { Text("Current PIN") },
+                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                    visualTransformation = PasswordVisualTransformation('*'),
+                    enabled = !currentPinVerified
+                )
+                Button(
+                    onClick = {
+                        hideKeyboard()
+                        focusManager.clearFocus(force = true)
+                        if (pinManager.checkPin(currentPin)) {
+                            currentPinVerified = true
+                            pinChangeError = null
+                            pinChangeMessage = "Current PIN confirmed."
+                        } else {
+                            pinChangeError = "Current PIN is incorrect."
+                            pinChangeMessage = null
+                        }
+                    },
+                    enabled = currentPin.length >= 4 && !currentPinVerified
+                ) {
+                    Text("Verify current PIN")
+                }
+                if (currentPinVerified) {
+                    OutlinedTextField(
+                        value = newPin,
+                        onValueChange = { input ->
+                            if (input.length <= 6 && input.all { it.isDigit() }) {
+                                newPin = input
+                                pinChangeError = null
+                                pinChangeMessage = null
+                            }
+                        },
+                        label = { Text("New PIN") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                        visualTransformation = PasswordVisualTransformation('*')
+                    )
+                    OutlinedTextField(
+                        value = confirmPin,
+                        onValueChange = { input ->
+                            if (input.length <= 6 && input.all { it.isDigit() }) {
+                                confirmPin = input
+                                pinChangeError = null
+                                pinChangeMessage = null
+                            }
+                        },
+                        label = { Text("Confirm new PIN") },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
+                        visualTransformation = PasswordVisualTransformation('*')
+                    )
+                    Button(
+                        onClick = {
+                            hideKeyboard()
+                            focusManager.clearFocus(force = true)
+                            when {
+                                newPin.length !in 4..6 -> {
+                                    pinChangeError = "PIN must be 4-6 digits."
+                                    pinChangeMessage = null
+                                }
+                                newPin != confirmPin -> {
+                                    pinChangeError = "PIN entries do not match."
+                                    pinChangeMessage = null
+                                }
+                                pinManager.updatePin(currentPin, newPin) -> {
+                                    onPinChanged(newPin)
+                                    pinChangeError = null
+                                    pinChangeMessage = "PIN updated successfully."
+                                    currentPin = ""
+                                    newPin = ""
+                                    confirmPin = ""
+                                    currentPinVerified = false
+                                }
+                                else -> {
+                                    pinChangeError = "Unable to update PIN. Please verify your current PIN."
+                                    pinChangeMessage = null
+                                    currentPinVerified = false
+                                }
+                            }
+                        },
+                        enabled = newPin.isNotEmpty() && confirmPin.isNotEmpty()
+                    ) {
+                        Text("Update PIN")
+                    }
+                }
+                pinChangeError?.let { error ->
+                    Text(
+                        error,
+                        color = MaterialTheme.colors.error,
+                        style = MaterialTheme.typography.caption
+                    )
+                }
+                pinChangeMessage?.let { message ->
+                    Text(
+                        message,
+                        color = MaterialTheme.colors.primary,
+                        style = MaterialTheme.typography.caption
+                    )
+                }
+                Text(
+                    "Changing your PIN does not update the PIN for previously exported archives.",
+                    style = MaterialTheme.typography.caption
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- prevent queued notifications from interrupting audio transcription and enlarge the record/stop controls
- remove the redundant PIN prompt when locking entries and reuse the stored credential
- add a change PIN workflow in settings that re-saves notes with the updated PIN

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cef3896e7083208593707ec7a67024