### PR TITLE
Fix fallback summary punctuation handling

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -416,7 +416,7 @@ class Summarizer(
 
         val summary = top.joinToString(" ") { candidate ->
             val endsWithTerminator = candidate.text.lastOrNull()?.let { it in SENTENCE_ENDINGS } ?: false
-            if (endsWithTerminator) candidate.text else "${'$'}{candidate.text}."
+            if (endsWithTerminator) candidate.text else "${candidate.text}."
         }
         return if (summary.isNotBlank()) summary else text.take(200)
     }


### PR DESCRIPTION
## Summary
- update the extractive fallback summary builder to append a period using the actual sentence text

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cef7319edc83208b5d5dff5d80d5d3