### PR TITLE
Refresh app icon

### DIFF
--- a/app/src/main/res/drawable/ic_notepad.xml
+++ b/app/src/main/res/drawable/ic_notepad.xml
@@ -4,52 +4,36 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
     <path
-        android:fillColor="#FFFFFF"
-        android:strokeColor="#1F2933"
+        android:fillColor="#FFFFFFFF"
+        android:strokeColor="#1F2937"
         android:strokeWidth="4"
         android:strokeLineJoin="round"
-        android:strokeLineCap="round"
-        android:pathData="M24,20h44v60h-44z" />
+        android:pathData="M36,24h36a8,8 0 0 1 8,8v44a8,8 0 0 1 -8,8h-36a8,8 0 0 1 -8,-8v-44a8,8 0 0 1 8,-8z" />
     <path
-        android:fillColor="#F4D35E"
-        android:strokeColor="#1F2933"
-        android:strokeWidth="3"
-        android:strokeLineJoin="round"
-        android:pathData="M24,20h8v60h-8z" />
+        android:fillColor="#0EA5E9"
+        android:strokeColor="#0EA5E9"
+        android:strokeWidth="0"
+        android:pathData="M32,32h44v10h-44z" />
     <path
-        android:strokeColor="#1F2933"
+        android:strokeColor="#1F2937"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M34,36h28" />
+        android:pathData="M36,50h36" />
     <path
-        android:strokeColor="#1F2933"
+        android:strokeColor="#1F2937"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M34,46h28" />
+        android:pathData="M36,60h28" />
     <path
-        android:strokeColor="#1F2933"
+        android:strokeColor="#1F2937"
         android:strokeWidth="3"
         android:strokeLineCap="round"
-        android:pathData="M34,56h28" />
+        android:pathData="M36,70h24" />
     <path
-        android:strokeColor="#1F2933"
-        android:strokeWidth="3"
-        android:strokeLineCap="round"
-        android:pathData="M34,66h20" />
-    <path
-        android:fillColor="#FFFFFF"
-        android:strokeColor="#1F2933"
-        android:strokeWidth="4"
+        android:fillColor="#00000000"
+        android:strokeColor="#38BDF8"
+        android:strokeWidth="5"
         android:strokeLineJoin="round"
         android:strokeLineCap="round"
-        android:pathData="M60,42l12,-12l24,24l-12,12z" />
-    <path
-        android:fillColor="#F4D35E"
-        android:strokeColor="#1F2933"
-        android:strokeWidth="4"
-        android:strokeLineJoin="round"
-        android:pathData="M84,66l12,12l-18,8z" />
-    <path
-        android:fillColor="#1F2933"
-        android:pathData="M70,36l6,-6l12,12l-6,6z" />
+        android:pathData="M38,66l11,11l19,-19" />
 </vector>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <resources>
     <color name="fab_color">#EC1A55</color>
-    <color name="ic_launcher_background">#EC1A55</color>
+    <color name="ic_launcher_background">#0F172A</color>
 </resources>


### PR DESCRIPTION
## Summary
- redesign the adaptive icon foreground vector with a cleaner, minimalist notebook and checkmark graphic
- shift the adaptive icon background to a deep corporate navy to better complement the refreshed foreground

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0239a13483209e152411cd008457