### PR TITLE
Add biometric unlock flow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-compose:2.7.7'
     implementation 'io.coil-kt:coil-compose:2.5.0'
     implementation 'androidx.activity:activity-compose:1.8.2'
+    implementation 'androidx.biometric:biometric:1.1.0'
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'

--- a/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
@@ -6,27 +6,41 @@ import android.content.SharedPreferences
 class PinManager(context: Context) {
     private val prefs: SharedPreferences = context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
 
-    fun isPinSet(): Boolean = prefs.contains("pin")
+    fun isPinSet(): Boolean = prefs.contains(KEY_PIN)
 
     fun setPin(pin: String) {
-        prefs.edit().putString("pin", pin).apply()
+        prefs.edit().putString(KEY_PIN, pin).apply()
     }
 
-    fun checkPin(pin: String): Boolean = prefs.getString("pin", null) == pin
+    fun checkPin(pin: String): Boolean = prefs.getString(KEY_PIN, null) == pin
 
-    fun getPinLength(): Int = prefs.getString("pin", null)?.length ?: 0
+    fun getPinLength(): Int = prefs.getString(KEY_PIN, null)?.length ?: 0
 
     fun updatePin(oldPin: String, newPin: String): Boolean {
-        val stored = prefs.getString("pin", null) ?: return false
+        val stored = prefs.getString(KEY_PIN, null) ?: return false
         return if (stored == oldPin) {
-            prefs.edit().putString("pin", newPin).apply()
+            prefs.edit().putString(KEY_PIN, newPin).apply()
             true
         } else {
             false
         }
     }
 
+    fun isBiometricEnabled(): Boolean = prefs.getBoolean(KEY_BIOMETRIC_ENABLED, false)
+
+    fun setBiometricEnabled(enabled: Boolean) {
+        prefs.edit().putBoolean(KEY_BIOMETRIC_ENABLED, enabled).apply()
+    }
+
     fun clearPin() {
-        prefs.edit().remove("pin").apply()
+        prefs.edit()
+            .remove(KEY_PIN)
+            .remove(KEY_BIOMETRIC_ENABLED)
+            .apply()
+    }
+
+    companion object {
+        private const val KEY_PIN = "pin"
+        private const val KEY_BIOMETRIC_ENABLED = "biometric_enabled"
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -11,9 +11,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.appcompat.app.AppCompatActivity
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.core.content.ContextCompat
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.PinManager
 import java.text.SimpleDateFormat
@@ -23,6 +28,8 @@ import java.util.Locale
 @Composable
 fun SettingsScreen(
     pinManager: PinManager,
+    biometricEnabled: Boolean,
+    onBiometricChanged: (Boolean) -> Unit,
     onBack: () -> Unit,
     onImport: (Uri, String, Boolean) -> Boolean,
     onExport: (Uri) -> Unit,
@@ -34,6 +41,92 @@ fun SettingsScreen(
     var selectedUri by remember { mutableStateOf<Uri?>(null) }
     val hideKeyboard = rememberKeyboardHider()
     val focusManager = LocalFocusManager.current
+    val context = LocalContext.current
+    val activity = remember(context) { context as AppCompatActivity }
+    val executor = remember(activity) { ContextCompat.getMainExecutor(activity) }
+    val biometricManager = remember(activity) { BiometricManager.from(activity) }
+    val biometricStatus = biometricManager.canAuthenticate(
+        BiometricManager.Authenticators.BIOMETRIC_STRONG or
+            BiometricManager.Authenticators.BIOMETRIC_WEAK
+    )
+    val biometricAvailable = biometricStatus == BiometricManager.BIOMETRIC_SUCCESS
+    val biometricNeedsEnrollment = biometricStatus == BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED
+    val biometricStatusMessage = when (biometricStatus) {
+        BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED ->
+            "No biometrics enrolled. Add a fingerprint or face in system settings."
+        BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE ->
+            "Biometric hardware is currently unavailable."
+        BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE ->
+            "Biometric hardware is not available on this device."
+        BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED ->
+            "A security update is required before biometrics can be used."
+        BiometricManager.BIOMETRIC_ERROR_UNSUPPORTED ->
+            "Biometric authentication is not supported on this device."
+        BiometricManager.BIOMETRIC_STATUS_UNKNOWN ->
+            "Biometric availability is currently unknown."
+        else -> null
+    }
+    val isPinCurrentlySet = pinManager.isPinSet()
+    var biometricChecked by remember { mutableStateOf(biometricEnabled) }
+    var biometricTarget by remember { mutableStateOf<Boolean?>(null) }
+    var biometricInProgress by remember { mutableStateOf(false) }
+    var biometricToggleError by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(biometricEnabled) {
+        biometricChecked = biometricEnabled
+    }
+
+    LaunchedEffect(isPinCurrentlySet) {
+        if (!isPinCurrentlySet && biometricEnabled) {
+            pinManager.setBiometricEnabled(false)
+            biometricChecked = false
+            onBiometricChanged(false)
+        }
+    }
+
+    val biometricPrompt = remember(activity, executor) {
+        BiometricPrompt(activity, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                val target = biometricTarget
+                if (target != null) {
+                    pinManager.setBiometricEnabled(target)
+                    onBiometricChanged(target)
+                    biometricChecked = target
+                    biometricToggleError = null
+                }
+                biometricTarget = null
+                biometricInProgress = false
+            }
+
+            override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
+                biometricToggleError = when (errorCode) {
+                    BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                    BiometricPrompt.ERROR_USER_CANCELED,
+                    BiometricPrompt.ERROR_CANCELED -> null
+                    else -> errString.toString()
+                }
+                biometricChecked = biometricEnabled
+                biometricTarget = null
+                biometricInProgress = false
+            }
+        })
+    }
+
+    LaunchedEffect(biometricTarget) {
+        val target = biometricTarget ?: return@LaunchedEffect
+        val promptInfo = BiometricPrompt.PromptInfo.Builder()
+            .setTitle(if (target) "Enable biometric unlock" else "Disable biometric unlock")
+            .setSubtitle(
+                if (target) {
+                    "Authenticate to enable unlocking notes with biometrics."
+                } else {
+                    "Authenticate to disable biometric unlock."
+                }
+            )
+            .setNegativeButtonText("Cancel")
+            .build()
+        biometricPrompt.authenticate(promptInfo)
+    }
     val importLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.GetContent()
     ) { uri ->
@@ -182,6 +275,85 @@ fun SettingsScreen(
                 exportLauncher.launch(name)
             }) {
                 Text("Export archived notes file")
+            }
+            Divider()
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("Biometric unlock", style = MaterialTheme.typography.h6)
+                        Text(
+                            "Use fingerprint or face authentication to unlock notes.",
+                            style = MaterialTheme.typography.body2
+                        )
+                    }
+                    Switch(
+                        checked = biometricChecked,
+                        onCheckedChange = { checked ->
+                            if (biometricInProgress) return@Switch
+                            biometricToggleError = null
+                            if (checked == biometricEnabled) {
+                                biometricChecked = biometricEnabled
+                                return@Switch
+                            }
+                            if (!isPinCurrentlySet && checked) {
+                                biometricChecked = false
+                                biometricToggleError = "Set a PIN before enabling biometrics."
+                                pinManager.setBiometricEnabled(false)
+                                onBiometricChanged(false)
+                                return@Switch
+                            }
+                            if (checked && !biometricAvailable) {
+                                biometricChecked = biometricEnabled
+                                biometricToggleError = biometricStatusMessage
+                                    ?: "Biometrics are unavailable."
+                                return@Switch
+                            }
+                            if (!checked && !biometricAvailable) {
+                                biometricChecked = false
+                                pinManager.setBiometricEnabled(false)
+                                onBiometricChanged(false)
+                                biometricToggleError = null
+                                return@Switch
+                            }
+                            biometricChecked = checked
+                            biometricTarget = checked
+                            biometricInProgress = true
+                        },
+                        enabled = !biometricInProgress && (isPinCurrentlySet || biometricChecked)
+                    )
+                }
+                if (!isPinCurrentlySet) {
+                    Text(
+                        "Set a PIN before enabling biometric unlock.",
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.error
+                    )
+                }
+                if (!biometricAvailable && biometricStatusMessage != null) {
+                    Text(
+                        biometricStatusMessage,
+                        style = MaterialTheme.typography.caption,
+                        color = if (biometricNeedsEnrollment) {
+                            MaterialTheme.colors.primary
+                        } else {
+                            MaterialTheme.colors.error
+                        }
+                    )
+                }
+                if (biometricInProgress) {
+                    Text(
+                        "Awaiting biometric confirmation...",
+                        style = MaterialTheme.typography.caption,
+                        color = MaterialTheme.colors.primary
+                    )
+                }
+                biometricToggleError?.let { error ->
+                    Text(
+                        error,
+                        color = MaterialTheme.colors.error,
+                        style = MaterialTheme.typography.caption
+                    )
+                }
             }
             Divider()
             Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {


### PR DESCRIPTION
## Summary
- add the AndroidX biometric dependency and store a biometric enabled flag in PinManager
- surface a biometric toggle in Settings that authenticates the user before changing enrollment
- invoke BiometricPrompt when opening locked notes and allow re-triggering it from the PIN dialog

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68cf0175c0148320ba06c79bcba54f74