### PR TITLE
Add event reminder scheduling and notifications

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -76,13 +76,19 @@ class EncryptedNoteStore(private val context: Context) {
             }
             val eventObj = obj.optJSONObject("event")
             val event = eventObj?.let {
+                val reminderMinutes = if (it.has("reminderMinutesBeforeStart") && !it.isNull("reminderMinutesBeforeStart")) {
+                    it.optInt("reminderMinutesBeforeStart")
+                } else {
+                    null
+                }
                 NoteEvent(
                     start = it.getLong("start"),
                     end = it.getLong("end"),
                     allDay = it.optBoolean("allDay", false),
                     timeZone = it.optString("timeZone", java.util.TimeZone.getDefault().id),
                     location = it.optString("location", null)
-                        ?.takeIf { location -> location.isNotBlank() }
+                        ?.takeIf { location -> location.isNotBlank() },
+                    reminderMinutesBeforeStart = reminderMinutes,
                 )
             }
             notes.add(
@@ -142,6 +148,7 @@ class EncryptedNoteStore(private val context: Context) {
                 eo.put("allDay", event.allDay)
                 eo.put("timeZone", event.timeZone)
                 event.location?.let { eo.put("location", it) }
+                event.reminderMinutesBeforeStart?.let { eo.put("reminderMinutesBeforeStart", it) }
                 obj.put("event", eo)
             }
             obj.put("locked", note.isLocked)

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -47,5 +47,6 @@ data class NoteEvent(
     val allDay: Boolean,
     val timeZone: String,
     val location: String? = null,
+    val reminderMinutesBeforeStart: Int? = null,
 )
 

--- a/app/src/main/java/com/example/starbucknotetaker/NoteReminderScheduler.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteReminderScheduler.kt
@@ -1,0 +1,59 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+
+class NoteReminderScheduler(context: Context) {
+    private val workManager = WorkManager.getInstance(context)
+
+    fun scheduleIfNeeded(note: Note) {
+        val event = note.event
+        val reminderMinutes = event?.reminderMinutesBeforeStart
+        if (event == null || reminderMinutes == null) {
+            cancel(note.id)
+            return
+        }
+        val triggerAt = event.start - TimeUnit.MINUTES.toMillis(reminderMinutes.toLong())
+        val now = System.currentTimeMillis()
+        if (triggerAt <= now) {
+            cancel(note.id)
+            return
+        }
+        val delay = triggerAt - now
+        val data = workDataOf(
+            NoteReminderWorker.KEY_NOTE_ID to note.id,
+            NoteReminderWorker.KEY_NOTE_TITLE to note.title,
+            NoteReminderWorker.KEY_NOTE_SUMMARY to note.summary,
+            NoteReminderWorker.KEY_EVENT_START to event.start,
+            NoteReminderWorker.KEY_EVENT_TIME_ZONE to event.timeZone,
+            NoteReminderWorker.KEY_EVENT_ALL_DAY to event.allDay,
+            NoteReminderWorker.KEY_EVENT_LOCATION to (event.location ?: ""),
+            NoteReminderWorker.KEY_NOTE_LOCKED to note.isLocked,
+            NoteReminderWorker.KEY_REMINDER_MINUTES to reminderMinutes,
+        )
+
+        val request = OneTimeWorkRequestBuilder<NoteReminderWorker>()
+            .setInitialDelay(delay, TimeUnit.MILLISECONDS)
+            .setInputData(data)
+            .addTag(workTag(note.id))
+            .build()
+
+        workManager.enqueueUniqueWork(uniqueWorkName(note.id), ExistingWorkPolicy.REPLACE, request)
+    }
+
+    fun cancel(noteId: Long) {
+        workManager.cancelUniqueWork(uniqueWorkName(noteId))
+    }
+
+    fun syncNotes(notes: List<Note>) {
+        notes.forEach { note -> scheduleIfNeeded(note) }
+    }
+
+    private fun uniqueWorkName(noteId: Long): String = "note-reminder-$noteId"
+
+    private fun workTag(noteId: Long): String = "note-reminder-tag-$noteId"
+}

--- a/app/src/main/java/com/example/starbucknotetaker/NoteReminderWorker.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteReminderWorker.kt
@@ -1,0 +1,153 @@
+package com.example.starbucknotetaker
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.app.TaskStackBuilder
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+class NoteReminderWorker(appContext: Context, params: WorkerParameters) : CoroutineWorker(appContext, params) {
+    override suspend fun doWork(): Result {
+        val noteId = inputData.getLong(KEY_NOTE_ID, -1L)
+        if (noteId <= 0) return Result.failure()
+        val title = inputData.getString(KEY_NOTE_TITLE) ?: return Result.failure()
+        val summary = inputData.getString(KEY_NOTE_SUMMARY).orEmpty()
+        val eventStart = inputData.getLong(KEY_EVENT_START, -1L)
+        if (eventStart <= 0) return Result.failure()
+        val allDay = inputData.getBoolean(KEY_EVENT_ALL_DAY, false)
+        val timeZoneId = inputData.getString(KEY_EVENT_TIME_ZONE) ?: ZoneId.systemDefault().id
+        val location = inputData.getString(KEY_EVENT_LOCATION).takeIf { !it.isNullOrBlank() }
+        val isLocked = inputData.getBoolean(KEY_NOTE_LOCKED, false)
+        val reminderMinutes = inputData.getInt(KEY_REMINDER_MINUTES, 0)
+
+        showNotification(
+            noteId = noteId,
+            title = title,
+            summary = summary,
+            eventStart = eventStart,
+            allDay = allDay,
+            timeZoneId = timeZoneId,
+            location = location,
+            isLocked = isLocked,
+            reminderMinutes = reminderMinutes,
+        )
+        return Result.success()
+    }
+
+    private fun showNotification(
+        noteId: Long,
+        title: String,
+        summary: String,
+        eventStart: Long,
+        allDay: Boolean,
+        timeZoneId: String,
+        location: String?,
+        isLocked: Boolean,
+        reminderMinutes: Int,
+    ) {
+        val context = applicationContext
+        ensureChannel(context)
+
+        val zone = runCatching { ZoneId.of(timeZoneId) }.getOrDefault(ZoneId.systemDefault())
+        val start = Instant.ofEpochMilli(eventStart).atZone(zone)
+        val formatter = if (allDay) DATE_FORMAT else DATE_TIME_FORMAT
+        val timeText = start.format(formatter)
+
+        val detailText = if (isLocked) {
+            context.getString(R.string.reminder_notification_locked_body)
+        } else {
+            buildString {
+                append(timeText)
+                if (!location.isNullOrBlank()) {
+                    append(" • ")
+                    append(location)
+                }
+                val trimmedSummary = summary.takeIf { it.isNotBlank() }
+                if (!trimmedSummary.isNullOrBlank()) {
+                    append('\n')
+                    append(trimmedSummary)
+                }
+            }.ifBlank { timeText }
+        }
+        val collapsedText = if (isLocked) {
+            context.getString(R.string.reminder_notification_locked_body)
+        } else {
+            detailText.lineSequence().firstOrNull().orEmpty().ifBlank { detailText }
+        }
+
+        val intent = Intent(context, MainActivity::class.java).apply {
+            action = MainActivity.ACTION_VIEW_NOTE_FROM_REMINDER
+            putExtra(MainActivity.EXTRA_NOTE_ID, noteId)
+        }
+        val pendingIntent = TaskStackBuilder.create(context).run {
+            addNextIntentWithParentStack(intent)
+            getPendingIntent(
+                noteId.hashCode(),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        } ?: return
+
+        val builder = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notepad)
+            .setContentTitle(context.getString(R.string.reminder_notification_title, title))
+            .setContentText(collapsedText)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(detailText))
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+            .setCategory(NotificationCompat.CATEGORY_EVENT)
+            .setVisibility(NotificationCompat.VISIBILITY_PRIVATE)
+            .setWhen(eventStart)
+            .setShowWhen(true)
+            .setContentIntent(pendingIntent)
+
+        if (!isLocked && reminderMinutes > 0) {
+            builder.setSubText(
+                context.getString(
+                    R.string.reminder_notification_subtext,
+                    formatReminderOffsetMinutes(reminderMinutes),
+                )
+            )
+        }
+
+        NotificationManagerCompat.from(context).notify(noteId.hashCode(), builder.build())
+    }
+
+    companion object {
+        const val KEY_NOTE_ID = "note_id"
+        const val KEY_NOTE_TITLE = "note_title"
+        const val KEY_NOTE_SUMMARY = "note_summary"
+        const val KEY_EVENT_START = "event_start"
+        const val KEY_EVENT_TIME_ZONE = "event_time_zone"
+        const val KEY_EVENT_ALL_DAY = "event_all_day"
+        const val KEY_EVENT_LOCATION = "event_location"
+        const val KEY_NOTE_LOCKED = "note_locked"
+        const val KEY_REMINDER_MINUTES = "reminder_minutes"
+
+        private const val CHANNEL_ID = "note-reminders"
+        private val DATE_TIME_FORMAT = DateTimeFormatter.ofPattern("MMM d, yyyy h:mm a")
+        private val DATE_FORMAT = DateTimeFormatter.ofPattern("MMM d, yyyy")
+
+        private fun ensureChannel(context: Context) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val manager = context.getSystemService(NotificationManager::class.java)
+                val channel = NotificationChannel(
+                    CHANNEL_ID,
+                    context.getString(R.string.reminder_notification_channel_name),
+                    NotificationManager.IMPORTANCE_HIGH
+                ).apply {
+                    description = context.getString(R.string.reminder_notification_channel_description)
+                }
+                manager?.createNotificationChannel(channel)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ReminderUtils.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ReminderUtils.kt
@@ -1,0 +1,24 @@
+package com.example.starbucknotetaker
+
+/**
+ * Supported reminder offsets expressed in minutes before the event start time.
+ */
+val REMINDER_MINUTE_OPTIONS = listOf(0, 5, 10, 15, 30, 60, 120, 240, 1440)
+
+/**
+ * Formats a reminder offset into a human readable label.
+ */
+fun formatReminderOffsetMinutes(minutes: Int): String {
+    if (minutes <= 0) {
+        return "At start time"
+    }
+    val days = minutes / 1440
+    if (minutes % 1440 == 0 && days > 0) {
+        return if (days == 1) "1 day before" else "$days days before"
+    }
+    val hours = minutes / 60
+    if (minutes % 60 == 0 && hours > 0) {
+        return if (hours == 1) "1 hour before" else "$hours hours before"
+    }
+    return if (minutes == 1) "1 minute before" else "$minutes minutes before"
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -6,6 +6,7 @@ import android.app.TimePickerDialog
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
 import android.provider.OpenableColumns
 import android.speech.SpeechRecognizer
 import android.widget.Toast
@@ -37,6 +38,7 @@ import coil.compose.rememberAsyncImagePainter
 import com.example.starbucknotetaker.LinkPreviewFetcher
 import com.example.starbucknotetaker.LinkPreviewResult
 import com.example.starbucknotetaker.NoteEvent
+import com.example.starbucknotetaker.REMINDER_MINUTE_OPTIONS
 import com.example.starbucknotetaker.NoteLinkPreview
 import com.example.starbucknotetaker.Summarizer
 import com.example.starbucknotetaker.UrlDetection
@@ -89,6 +91,29 @@ fun AddNoteScreen(
     }
     val dateFormatter = remember { DateTimeFormatter.ofPattern("EEE, MMM d, yyyy") }
     val timeFormatter = remember { DateTimeFormatter.ofPattern("HH:mm") }
+    var reminderEnabled by remember(initialEvent) {
+        mutableStateOf(initialEvent?.reminderMinutesBeforeStart != null)
+    }
+    var reminderMinutes by remember(initialEvent) {
+        mutableStateOf(initialEvent?.reminderMinutesBeforeStart ?: REMINDER_MINUTE_OPTIONS.getOrElse(4) { 30 })
+    }
+    var pendingReminderPermission by remember { mutableStateOf(false) }
+    val notificationPermissionLauncher =
+        rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+            if (pendingReminderPermission) {
+                if (granted) {
+                    reminderEnabled = true
+                } else {
+                    Toast.makeText(
+                        context,
+                        "Notification permission is required to enable reminders",
+                        Toast.LENGTH_LONG
+                    ).show()
+                    reminderEnabled = false
+                }
+                pendingReminderPermission = false
+            }
+        }
 
     fun syncLinkPreviews(
         index: Int,
@@ -338,6 +363,7 @@ fun AddNoteScreen(
                                 allDay = eventAllDay,
                                 timeZone = zoneId.id,
                                 location = eventLocation.takeIf { it.isNotBlank() },
+                                reminderMinutesBeforeStart = reminderMinutes.takeIf { reminderEnabled },
                             )
                         } else {
                             null
@@ -495,6 +521,42 @@ fun AddNoteScreen(
                             },
                             modifier = Modifier.fillMaxWidth()
                         )
+                        Spacer(modifier = Modifier.height(8.dp))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text("Reminder")
+                            Spacer(modifier = Modifier.width(8.dp))
+                            Switch(
+                                checked = reminderEnabled,
+                                onCheckedChange = { checked ->
+                                    if (checked) {
+                                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                            val granted = ContextCompat.checkSelfPermission(
+                                                context,
+                                                Manifest.permission.POST_NOTIFICATIONS
+                                            ) == PackageManager.PERMISSION_GRANTED
+                                            if (!granted) {
+                                                pendingReminderPermission = true
+                                                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+                                                return@Switch
+                                            }
+                                        }
+                                        reminderEnabled = true
+                                    } else {
+                                        reminderEnabled = false
+                                    }
+                                }
+                            )
+                        }
+                        if (reminderEnabled) {
+                            Spacer(modifier = Modifier.height(8.dp))
+                            ReminderOffsetDropdown(
+                                selectedMinutes = reminderMinutes,
+                                onMinutesSelected = { reminderMinutes = it },
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EventReminderComponents.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EventReminderComponents.kt
@@ -1,0 +1,57 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.ExposedDropdownMenuBox
+import androidx.compose.material.ExposedDropdownMenuDefaults
+import androidx.compose.material.OutlinedTextField
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.example.starbucknotetaker.REMINDER_MINUTE_OPTIONS
+import com.example.starbucknotetaker.formatReminderOffsetMinutes
+
+@OptIn(ExperimentalMaterialApi::class)
+@Composable
+fun ReminderOffsetDropdown(
+    selectedMinutes: Int,
+    onMinutesSelected: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var expanded by remember { mutableStateOf(false) }
+    val label = formatReminderOffsetMinutes(selectedMinutes)
+
+    ExposedDropdownMenuBox(expanded = expanded, onExpandedChange = { expanded = it }) {
+        OutlinedTextField(
+            value = label,
+            onValueChange = {},
+            readOnly = true,
+            label = { Text("Reminder lead time") },
+            trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
+            modifier = modifier.fillMaxWidth(),
+        )
+        ExposedDropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            val options = if (REMINDER_MINUTE_OPTIONS.contains(selectedMinutes)) {
+                REMINDER_MINUTE_OPTIONS
+            } else {
+                listOf(selectedMinutes) + REMINDER_MINUTE_OPTIONS
+            }
+            options.distinct().forEach { minutes ->
+                DropdownMenuItem(onClick = {
+                    expanded = false
+                    onMinutesSelected(minutes)
+                }) {
+                    Text(formatReminderOffsetMinutes(minutes))
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,8 @@
 <resources>
     <string name="app_name">Starbuck Notes</string>
+    <string name="reminder_notification_channel_name">Event reminders</string>
+    <string name="reminder_notification_channel_description">Notifications before your note events begin.</string>
+    <string name="reminder_notification_title">Upcoming event: %1$s</string>
+    <string name="reminder_notification_locked_body">Unlock with your PIN to view details.</string>
+    <string name="reminder_notification_subtext">Reminder %1$s</string>
 </resources>


### PR DESCRIPTION
## Summary
- extend event entry UI to toggle reminders, request notification permission, and pick a lead time when creating or editing notes with events
- persist reminder metadata on `NoteEvent`, serialize it in the encrypted store, and add reusable reminder formatting helpers
- schedule WorkManager jobs per note to show reminder notifications with deep links, and handle reminder-triggered navigation in the view model and activity

## Testing
- `./gradlew test` *(hangs after completing unit tests; terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_68cf017ae3548320bfc2693f946cda17