### PR TITLE
Limit note detail title lines

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.Note
 import com.example.starbucknotetaker.NoteEvent
@@ -57,7 +58,13 @@ fun NoteDetailScreen(
     var fullImage by remember { mutableStateOf<String?>(null) }
     Scaffold(topBar = {
         TopAppBar(
-            title = { Text(note.title) },
+            title = {
+                Text(
+                    note.title,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            },
             navigationIcon = {
                 IconButton(onClick = onBack) {
                     Icon(


### PR DESCRIPTION
## Summary
- limit note detail top app bar title to two lines and ellipsize overflow

## Testing
- ./gradlew lint

------
https://chatgpt.com/codex/tasks/task_e_68cf05cfa72c8320aa4df484d49f155a