### PR TITLE
Handle shared content when creating notes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,22 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="application/*" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/*" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="application/*" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.mutableStateListOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import java.net.URL
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.launch
 import android.provider.OpenableColumns
 import android.widget.Toast
@@ -38,6 +39,8 @@ class NoteViewModel : ViewModel() {
     private val _summarizerState = MutableStateFlow<Summarizer.SummarizerState>(Summarizer.SummarizerState.Ready)
     val summarizerState: StateFlow<Summarizer.SummarizerState> = _summarizerState
     private val unlockedNoteIds = mutableStateListOf<Long>()
+    private val _pendingShare = MutableStateFlow<PendingShare?>(null)
+    val pendingShare: StateFlow<PendingShare?> = _pendingShare
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -194,6 +197,14 @@ class NoteViewModel : ViewModel() {
 
     fun relockNote(id: Long) {
         unlockedNoteIds.remove(id)
+    }
+
+    fun setPendingShare(share: PendingShare?) {
+        _pendingShare.value = share
+    }
+
+    fun clearPendingShare() {
+        _pendingShare.value = null
     }
 
     fun setNoteLock(id: Long, locked: Boolean) {
@@ -423,3 +434,13 @@ class NoteViewModel : ViewModel() {
         }
     }
 }
+
+private val pendingShareIdGenerator = AtomicLong(0L)
+
+data class PendingShare(
+    val title: String?,
+    val text: String?,
+    val images: List<Uri> = emptyList(),
+    val files: List<Uri> = emptyList(),
+    val id: Long = pendingShareIdGenerator.incrementAndGet(),
+)


### PR DESCRIPTION
## Summary
- add send/send_multiple intent filters so sharing to the app is surfaced to MainActivity
- capture shared text, images, and files in MainActivity, expose them via NoteViewModel, and auto-open the composer when unlocked
- prefill AddNoteScreen with pending shared content and clear the share once the user saves or cancels

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cf07b631748320b6bf8b6a1a8df623