### PR TITLE
Handle shared content when launching add note

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,19 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="text/plain" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.SEND_MULTIPLE" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+                <data android:mimeType="*/*" />
+            </intent-filter>
         </activity>
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -49,6 +49,8 @@ class NoteViewModel : ViewModel() {
     )
     val reminderNavigation: SharedFlow<Long> = reminderNavigationEvents.asSharedFlow()
     private var pendingReminderNoteId: Long? = null
+    private val _pendingShare = MutableStateFlow<PendingShare?>(null)
+    val pendingShare: StateFlow<PendingShare?> = _pendingShare
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -90,6 +92,14 @@ class NoteViewModel : ViewModel() {
                 }
             }
         }
+    }
+
+    fun setPendingShare(pending: PendingShare?) {
+        _pendingShare.value = pending
+    }
+
+    fun clearPendingShare() {
+        _pendingShare.value = null
     }
 
     fun addNote(
@@ -470,3 +480,10 @@ class NoteViewModel : ViewModel() {
         }
     }
 }
+
+data class PendingShare(
+    val title: String?,
+    val text: String?,
+    val images: List<Uri>,
+    val files: List<Uri>,
+)


### PR DESCRIPTION
## Summary
- add SEND and SEND_MULTIPLE intent filters so the activity can receive shared text, images, or files
- parse share intents in `MainActivity` to populate a pending share in the view model and navigate to the add screen when appropriate
- pre-populate `AddNoteScreen` from the pending share data and clear it after the user saves or leaves the screen

## Testing
- `./gradlew lintDebug` *(fails: existing MissingPermission in NoteReminderWorker)*

------
https://chatgpt.com/codex/tasks/task_e_68cf0c6fe0bc832099e41321148e094c