### PR TITLE
Improve calendar location search and timezone input

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/ZoneUtils.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/ZoneUtils.kt
@@ -16,14 +16,11 @@ internal fun formatZoneCode(
     val hours = totalSeconds / 3600
     val minutes = abs(totalSeconds % 3600) / 60
 
-    val rawShortName = zoneId.getDisplayName(TextStyle.SHORT, locale)
-    val sanitizedShortName = rawShortName.takeIf { shortName ->
-        shortName.isNotBlank() &&
-            shortName.any { it.isLetter() } &&
-            shortName.none { it.isDigit() } &&
-            !shortName.contains('+') &&
-            !shortName.contains('-')
-    } ?: "GMT"
+    val base = if (totalSeconds == 0) {
+        "GMT"
+    } else {
+        "UTC"
+    }
 
     val sign = if (totalSeconds >= 0) "+" else "-"
     val hourComponent = String.format(Locale.US, "%d", abs(hours))
@@ -34,7 +31,7 @@ internal fun formatZoneCode(
     }
 
     return buildString {
-        append(sanitizedShortName)
+        append(base)
         append(sign)
         append(hourComponent)
         append(minuteComponent)


### PR DESCRIPTION
## Summary
- keep the calendar location and time zone fields focused by requesting keyboard when typing or selecting options
- enrich location suggestions with business and venue names and keep the keyboard visible
- display time zone abbreviations in UTC/GMT offset format for clarity

## Testing
- `./gradlew test` *(fails: command hung and Gradle was terminated after an extended time)*

------
https://chatgpt.com/codex/tasks/task_e_68cf1c73235483208af72889eb536a76