### PR TITLE
Fix summarizer fallback debugging strings

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -434,7 +434,7 @@ class NoteViewModel : ViewModel() {
         }.trim()
         val summaryText = reason?.takeIf { it.isNotBlank() } ?: "Summarizer fallback triggered"
         val note = Note(
-            title = "Summarizer Debug – $referencedTitle (#${'$'}{debugNoteCounter++})",
+            title = "Summarizer Debug – $referencedTitle (#${debugNoteCounter++})",
             content = content,
             summary = summaryText.take(200),
             date = System.currentTimeMillis(),

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
@@ -1,0 +1,53 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class SummarizerFallbackTest {
+
+    @Test
+    fun fallbackTraceIncludesReasonAndSentences() = runTest {
+        val context = mock<Context>()
+        val fetcher = mock<ModelFetcher>()
+        runBlocking {
+            whenever(fetcher.ensureModels(any())).thenReturn(ModelFetcher.Result.Failure("fail to fetch"))
+        }
+        val debugMessages = mutableListOf<String>()
+        val summarizer = Summarizer(
+            context = context,
+            fetcher = fetcher,
+            spFactory = { throw AssertionError("tokenizer should not be created in fallback") },
+            nativeLoader = { throw AssertionError("native loader should not be invoked in fallback") },
+            interpreterFactory = { throw AssertionError("interpreter should not be created in fallback") },
+            logger = { _, _ -> },
+            debugSink = { debugMessages.add(it) }
+        )
+
+        val source = "First sentence has coffee beans. Second sentence talks about roasting beans. Third sentence is ignored."
+        val summary = summarizer.summarize(source)
+
+        assertFalse(summary.isBlank())
+
+        val trace = summarizer.consumeDebugTrace()
+        assertTrue(
+            "Expected fallback reason to appear in trace, got: $trace",
+            trace.any { it.contains("fallback reason: models unavailable") }
+        )
+        assertTrue(
+            "Expected fallback sentence log with actual text, got: $trace",
+            trace.any { it.contains("fallback sentence[0]") && it.contains("coffee beans") }
+        )
+        assertTrue(
+            "Expected fallback sentence log with actual text, got: $trace",
+            trace.any { it.contains("fallback sentence[1]") && it.contains("roasting beans") }
+        )
+    }
+}
+


### PR DESCRIPTION
## Summary
- replace escaped Kotlin interpolation in the summarizer fallback debug messages so trace entries show concrete values
- fix the summarizer debug note title to interpolate the incrementing counter
- add a unit test that exercises the fallback path and asserts the trace contains the reason and extracted sentences

## Testing
- ./gradlew -Dorg.gradle.console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68cf3695c9588320ab70b2fce5b1270d