### PR TITLE
Auto load notes after PIN setup and offer biometric opt-in

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
@@ -12,6 +12,8 @@ class PinManager(context: Context) {
         prefs.edit().putString(KEY_PIN, pin).apply()
     }
 
+    fun getStoredPin(): String? = prefs.getString(KEY_PIN, null)
+
     fun checkPin(pin: String): Boolean = prefs.getString(KEY_PIN, null) == pin
 
     fun getPinLength(): Int = prefs.getString(KEY_PIN, null)?.length ?: 0


### PR DESCRIPTION
## Summary
- skip the PIN entry screen on launch by loading notes with the stored PIN
- prompt new users to opt into biometric unlock and persist their choice in settings
- expose the stored PIN through PinManager for automatic loading

## Testing
- ./gradlew testReleaseUnitTest --console=plain
- ./gradlew testDebugUnitTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68cf40cacd508320912721fb4781bb25