### PR TITLE
Update app icon accent color

### DIFF
--- a/app/src/main/res/drawable/ic_notepad.xml
+++ b/app/src/main/res/drawable/ic_notepad.xml
@@ -10,8 +10,8 @@
         android:strokeLineJoin="round"
         android:pathData="M36,24h36a8,8 0 0 1 8,8v44a8,8 0 0 1 -8,8h-36a8,8 0 0 1 -8,-8v-44a8,8 0 0 1 8,-8z" />
     <path
-        android:fillColor="#0EA5E9"
-        android:strokeColor="#0EA5E9"
+        android:fillColor="#EC1A55"
+        android:strokeColor="#EC1A55"
         android:strokeWidth="0"
         android:pathData="M32,32h44v10h-44z" />
     <path
@@ -31,7 +31,7 @@
         android:pathData="M36,70h24" />
     <path
         android:fillColor="#00000000"
-        android:strokeColor="#38BDF8"
+        android:strokeColor="#EC1A55"
         android:strokeWidth="5"
         android:strokeLineJoin="round"
         android:strokeLineCap="round"


### PR DESCRIPTION
## Summary
- update the notepad vector icon to use the app's vibrant pink for the header band and checkmark

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cff9021f4883209663672b155d3286