### PR TITLE
Ensure unlocked notes navigate after authentication

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -48,6 +48,11 @@ class NoteViewModel : ViewModel() {
         onBufferOverflow = BufferOverflow.DROP_OLDEST,
     )
     val reminderNavigation: SharedFlow<Long> = reminderNavigationEvents.asSharedFlow()
+    private val openNoteRequests = MutableSharedFlow<Long>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+    val openNoteEvents: SharedFlow<Long> = openNoteRequests.asSharedFlow()
     private var pendingReminderNoteId: Long? = null
     private val _pendingShare = MutableStateFlow<PendingShare?>(null)
     val pendingShare: StateFlow<PendingShare?> = _pendingShare
@@ -236,6 +241,10 @@ class NoteViewModel : ViewModel() {
         if (!unlockedNoteIds.contains(id)) {
             unlockedNoteIds.add(id)
         }
+    }
+
+    fun requestOpenTemporarilyUnlockedNote(id: Long) {
+        openNoteRequests.tryEmit(id)
     }
 
     fun relockNote(id: Long) {


### PR DESCRIPTION
## Summary
- add a shared flow in NoteViewModel to emit navigation events when a note becomes temporarily unlocked
- collect the unlock navigation events in AppContent so both biometric and PIN confirmations open the detail screen reliably
- skip redisplaying the PIN dialog when the note is already unlocked and immediately request navigation instead

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68cff85617a083209023fa475e66b8c8