### PR TITLE
Improve PIN setup UX

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.VisualTransformation
@@ -52,7 +53,7 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
             reveal = false
         }
     }
-    LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    LaunchedEffect(firstPin) { focusRequester.requestFocus() }
 
     val message = if (firstPin == null) {
         "Create a custom PIN"
@@ -76,14 +77,20 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
                 if (input.length <= 6 && input.all { it.isDigit() }) {
                     pin = input
                     reveal = true
+                    if (input.isNotEmpty()) {
+                        error = null
+                    }
                 }
             },
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
             visualTransformation = PinVisualTransformation(reveal),
             singleLine = true,
-            textStyle = androidx.compose.material.LocalTextStyle.current.copy(
-                textAlign = TextAlign.Center,
-                fontSize = 64.sp
+            textStyle = androidx.compose.material.LocalTextStyle.current.merge(
+                TextStyle(
+                    textAlign = TextAlign.Center,
+                    fontSize = 64.sp,
+                    lineHeight = 64.sp
+                )
             ),
             colors = TextFieldDefaults.textFieldColors(
                 backgroundColor = Color.Transparent,
@@ -114,8 +121,10 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
                         pinManager.setPin(pin)
                         onDone(pin)
                     } else {
-                        error = "PINs do not match"
+                        error = "PINs did not match"
+                        firstPin = null
                         pin = ""
+                        reveal = false
                     }
                 }
             },
@@ -180,9 +189,12 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
                 keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.NumberPassword),
                 visualTransformation = PinVisualTransformation(reveal),
                 singleLine = true,
-                textStyle = androidx.compose.material.LocalTextStyle.current.copy(
-                    textAlign = TextAlign.Center,
-                    fontSize = 64.sp
+                textStyle = androidx.compose.material.LocalTextStyle.current.merge(
+                    TextStyle(
+                        textAlign = TextAlign.Center,
+                        fontSize = 64.sp,
+                        lineHeight = 64.sp
+                    )
                 ),
                 colors = TextFieldDefaults.textFieldColors(
                     backgroundColor = Color.Transparent,


### PR DESCRIPTION
## Summary
- align PIN text fields with an explicit text style so the initial cursor matches the digit size
- reset the PIN creation flow after a mismatch and surface a red error message on the first entry step

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d009e94fd883208ee6f9039bee1b05