### PR TITLE
Fix time zone picker overlay and zone-aware reminders

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/ZoneUtils.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/ZoneUtils.kt
@@ -2,6 +2,7 @@ package com.example.starbucknotetaker.ui
 
 import java.time.Instant
 import java.time.ZoneId
+import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
 import java.util.Locale
 import kotlin.math.abs
@@ -11,6 +12,22 @@ internal fun formatZoneCode(
     locale: Locale = Locale.getDefault(),
     instant: Instant = Instant.now(),
 ): String {
+    val zonedDateTime = instant.atZone(zoneId)
+    val formatter = DateTimeFormatter.ofPattern("zzz", locale)
+    val shortName = runCatching { formatter.format(zonedDateTime) }
+        .getOrNull()
+        .orEmpty()
+        .trim()
+
+    val normalized = shortName.takeIf { it.isNotEmpty() }
+    val looksLikeRawOffset = normalized?.let {
+        (it.startsWith("GMT", ignoreCase = true) || it.startsWith("UTC", ignoreCase = true)) && it.length > 3
+    } == true
+
+    if (normalized != null && !looksLikeRawOffset) {
+        return normalized
+    }
+
     val offset = zoneId.rules.getOffset(instant)
     val totalSeconds = offset.totalSeconds
     val hours = totalSeconds / 3600


### PR DESCRIPTION
## Summary
- rework the calendar time zone picker to show inline suggestions that stay behind the keyboard
- display locale-specific time zone abbreviations (such as CET/GMT) with an offset fallback
- compute reminder scheduling using the event's time zone instant before enqueueing work

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d010f592908320be2f402867a79733