### PR TITLE
Fix share cleanup observer for attachments

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -133,10 +133,23 @@ fun NoteDetailScreen(
                             if (attachments.isNotEmpty()) {
                                 val lifecycle = lifecycleOwner.lifecycle
                                 val observer = object : LifecycleEventObserver {
-                                    override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
-                                        if (event == Lifecycle.Event.ON_RESUME || event == Lifecycle.Event.ON_DESTROY) {
-                                            cleanupSharedFiles(context, attachments)
-                                            lifecycle.removeObserver(this)
+                                    private var hasStopped = false
+
+                                    override fun onStateChanged(
+                                        source: LifecycleOwner,
+                                        event: Lifecycle.Event
+                                    ) {
+                                        when (event) {
+                                            Lifecycle.Event.ON_STOP -> hasStopped = true
+                                            Lifecycle.Event.ON_RESUME -> if (hasStopped) {
+                                                cleanupSharedFiles(context, attachments)
+                                                lifecycle.removeObserver(this)
+                                            }
+                                            Lifecycle.Event.ON_DESTROY -> {
+                                                cleanupSharedFiles(context, attachments)
+                                                lifecycle.removeObserver(this)
+                                            }
+                                            else -> Unit
                                         }
                                     }
                                 }


### PR DESCRIPTION
## Summary
- delay share attachment cleanup until the note screen resumes after being stopped
- continue to clean up attachments if the screen is destroyed while sharing

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d07ccfef888320930c79caff416365