### PR TITLE
Persist biometric unlock request across configuration changes

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
@@ -1,0 +1,3 @@
+package com.example.starbucknotetaker
+
+data class BiometricUnlockRequest(val noteId: Long, val title: String)

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -51,6 +51,8 @@ class NoteViewModel : ViewModel() {
     private var pendingReminderNoteId: Long? = null
     private val _pendingShare = MutableStateFlow<PendingShare?>(null)
     val pendingShare: StateFlow<PendingShare?> = _pendingShare
+    private val _biometricUnlockRequest = MutableStateFlow<BiometricUnlockRequest?>(null)
+    val biometricUnlockRequest: StateFlow<BiometricUnlockRequest?> = _biometricUnlockRequest
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -100,6 +102,18 @@ class NoteViewModel : ViewModel() {
 
     fun clearPendingShare() {
         _pendingShare.value = null
+    }
+
+    fun requestBiometricUnlock(noteId: Long, title: String) {
+        _biometricUnlockRequest.value = BiometricUnlockRequest(noteId, title)
+    }
+
+    fun clearBiometricUnlockRequest() {
+        _biometricUnlockRequest.value = null
+    }
+
+    fun currentBiometricUnlockRequest(): BiometricUnlockRequest? {
+        return _biometricUnlockRequest.value
     }
 
     fun addNote(


### PR DESCRIPTION
## Summary
- persist the biometric unlock request in `NoteViewModel` so it survives configuration changes
- update biometric callbacks and the PIN dialog to use the shared request state
- add a shared `BiometricUnlockRequest` data class for the prompt metadata

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d07efbb17c83209deac0f53d9af227