### PR TITLE
Persist pending open note state across configuration changes

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -53,6 +53,8 @@ class NoteViewModel : ViewModel() {
     val pendingShare: StateFlow<PendingShare?> = _pendingShare
     private val _biometricUnlockRequest = MutableStateFlow<BiometricUnlockRequest?>(null)
     val biometricUnlockRequest: StateFlow<BiometricUnlockRequest?> = _biometricUnlockRequest
+    private val _pendingOpenNoteId = MutableStateFlow<Long?>(null)
+    val pendingOpenNoteId: StateFlow<Long?> = _pendingOpenNoteId
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -114,6 +116,14 @@ class NoteViewModel : ViewModel() {
 
     fun currentBiometricUnlockRequest(): BiometricUnlockRequest? {
         return _biometricUnlockRequest.value
+    }
+
+    fun setPendingOpenNoteId(noteId: Long) {
+        _pendingOpenNoteId.value = noteId
+    }
+
+    fun clearPendingOpenNoteId() {
+        _pendingOpenNoteId.value = null
     }
 
     fun addNote(


### PR DESCRIPTION
## Summary
- move the pending open note id state into NoteViewModel alongside other unlock flows
- update AppContent to read and mutate the ViewModel-backed state so the PIN dialog survives rotations

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d0bd90060c8320b209856bbc0bc48e