### PR TITLE
Persist pending unlocked note navigation

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -58,6 +58,8 @@ class NoteViewModel(
     val biometricUnlockRequest: StateFlow<BiometricUnlockRequest?> = _biometricUnlockRequest
     val pendingOpenNoteId: StateFlow<Long?> =
         savedStateHandle.getStateFlow(PENDING_OPEN_NOTE_ID_KEY, null)
+    val noteIdToOpenAfterUnlock: StateFlow<Long?> =
+        savedStateHandle.getStateFlow(NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY, null)
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -129,8 +131,17 @@ class NoteViewModel(
         savedStateHandle[PENDING_OPEN_NOTE_ID_KEY] = null
     }
 
+    fun setNoteIdToOpenAfterUnlock(noteId: Long) {
+        savedStateHandle[NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY] = noteId
+    }
+
+    fun clearNoteIdToOpenAfterUnlock() {
+        savedStateHandle[NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY] = null
+    }
+
     private companion object {
         const val PENDING_OPEN_NOTE_ID_KEY = "pending_open_note_id"
+        const val NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY = "note_id_to_open_after_unlock"
     }
 
     fun addNote(


### PR DESCRIPTION
## Summary
- store the note ID to open after authentication in `NoteViewModel` so it survives configuration changes
- update biometric and PIN unlock flows to write through the new state holder and consume it from Compose
- tidy the note detail/edit composables to avoid nullable warnings while navigating

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68d12d71261483208c47892d55ba191b