### PR TITLE
Persist note attachments via encrypted storage

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/AttachmentStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/AttachmentStore.kt
@@ -1,0 +1,85 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import java.io.File
+import java.security.SecureRandom
+import java.util.UUID
+import javax.crypto.Cipher
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.GCMParameterSpec
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
+
+class AttachmentStore(private val context: Context) {
+    private val directory: File = File(context.filesDir, "attachments")
+    private val secureRandom = SecureRandom()
+
+    init {
+        ensureDirectory()
+    }
+
+    fun saveAttachment(pin: String, bytes: ByteArray, id: String? = null): String {
+        ensureDirectory()
+        val attachmentId = id ?: UUID.randomUUID().toString()
+        val salt = ByteArray(16).also(secureRandom::nextBytes)
+        val iv = ByteArray(12).also(secureRandom::nextBytes)
+        val cipher = Cipher.getInstance("AES/GCM/NoPadding")
+        val key = deriveKey(pin, salt)
+        cipher.init(Cipher.ENCRYPT_MODE, key, GCMParameterSpec(128, iv))
+        val cipherText = cipher.doFinal(bytes)
+        val output = ByteArray(16 + 12 + cipherText.size)
+        System.arraycopy(salt, 0, output, 0, 16)
+        System.arraycopy(iv, 0, output, 16, 12)
+        System.arraycopy(cipherText, 0, output, 28, cipherText.size)
+        attachmentFile(attachmentId).writeBytes(output)
+        return attachmentId
+    }
+
+    fun openAttachment(pin: String, id: String): ByteArray? {
+        val file = attachmentFile(id)
+        if (!file.exists()) {
+            return null
+        }
+        val bytes = runCatching { file.readBytes() }.getOrNull() ?: return null
+        if (bytes.size < 28) {
+            return null
+        }
+        val salt = bytes.copyOfRange(0, 16)
+        val iv = bytes.copyOfRange(16, 28)
+        val cipherText = bytes.copyOfRange(28, bytes.size)
+        val cipher = runCatching { Cipher.getInstance("AES/GCM/NoPadding") }.getOrNull()
+            ?: return null
+        val key = deriveKey(pin, salt)
+        return runCatching {
+            cipher.init(Cipher.DECRYPT_MODE, key, GCMParameterSpec(128, iv))
+            cipher.doFinal(cipherText)
+        }.getOrNull()
+    }
+
+    fun deleteAttachment(id: String) {
+        runCatching { attachmentFile(id).takeIf(File::exists)?.delete() }
+    }
+
+    fun reencryptAttachment(oldPin: String, newPin: String, id: String): Boolean {
+        val plain = openAttachment(oldPin, id) ?: return false
+        saveAttachment(newPin, plain, id)
+        return true
+    }
+
+    private fun attachmentFile(id: String): File {
+        return File(directory, "$id.bin")
+    }
+
+    private fun ensureDirectory() {
+        if (!directory.exists()) {
+            directory.mkdirs()
+        }
+    }
+
+    private fun deriveKey(pin: String, salt: ByteArray): SecretKeySpec {
+        val spec = PBEKeySpec(pin.toCharArray(), salt, 10000, 256)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val bytes = factory.generateSecret(spec).encoded
+        return SecretKeySpec(bytes, "AES")
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -491,7 +491,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                         noteViewModel.setNoteLock(note.id, true)
                         noteViewModel.markNoteTemporarilyUnlocked(note.id)
                     },
-                    onUnlockRequest = { pendingUnlockNoteId = note.id }
+                    onUnlockRequest = { pendingUnlockNoteId = note.id },
+                    openAttachment = { id -> noteViewModel.openAttachment(id) }
                 )
             } else {
                 navController.popBackStack()
@@ -510,7 +511,8 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                     onCancel = { navController.popBackStack() },
                     onDisablePinCheck = {},
                     onEnablePinCheck = {},
-                    summarizerState = summarizerState
+                    summarizerState = summarizerState,
+                    openAttachment = { id -> noteViewModel.openAttachment(id) }
                 )
             } else {
                 navController.popBackStack()

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -8,7 +8,7 @@ data class Note(
     val title: String,
     val content: String,
     val date: Long = System.currentTimeMillis(),
-    val images: List<String> = emptyList(),
+    val images: List<NoteImage> = emptyList(),
     val files: List<NoteFile> = emptyList(),
     val linkPreviews: List<NoteLinkPreview> = emptyList(),
     val summary: String = "",
@@ -24,7 +24,19 @@ data class Note(
 data class NoteFile(
     val name: String,
     val mime: String,
-    val data: String,
+    val attachmentId: String? = null,
+    val data: String? = null,
+)
+
+/**
+ * Represents an embedded image within a note. Images are stored externally via
+ * the attachment store and referenced by a stable identifier. The deprecated
+ * [data] property is temporarily retained so legacy notes encoded with base64
+ * blobs can still be opened and migrated.
+ */
+data class NoteImage(
+    val attachmentId: String? = null,
+    val data: String? = null,
 )
 
 /**


### PR DESCRIPTION
## Summary
- create an AttachmentStore that writes encrypted attachment blobs using the note PIN and supports re-encryption and cleanup
- migrate note models, persistence, and the view model to work with attachment IDs while streaming new content into the store and deleting orphaned files
- update editing and detail UIs to resolve attachment bytes on demand for display, sharing, and file actions

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d135d313148320bb87bb456965694e