### PR TITLE
Integrate classifier-based summarization

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteNatureClassifier.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteNatureClassifier.kt
@@ -20,9 +20,9 @@ import kotlin.math.max
  * matches, structural cues (such as bullet lists), and optional calendar event metadata. When no
  * category achieves a reasonable score the classifier returns a general-purpose label.
  */
-class NoteNatureClassifier {
+open class NoteNatureClassifier {
 
-    suspend fun classify(text: String, event: NoteEvent?): NoteNatureLabel {
+    open suspend fun classify(text: String, event: NoteEvent?): NoteNatureLabel {
         val trimmed = text.trim()
         if (trimmed.isEmpty()) {
             return FALLBACK_LABEL
@@ -60,7 +60,8 @@ class NoteNatureClassifier {
         }
 
         val type = best.key
-        return NoteNatureLabel(type, type.humanReadable)
+        val confidence = relativeScore.coerceIn(0.0, 1.0)
+        return NoteNatureLabel(type, type.humanReadable, confidence)
     }
 
     private fun normalizeTokens(text: String): List<String> {
@@ -113,7 +114,11 @@ class NoteNatureClassifier {
     }
 
     companion object {
-        private val FALLBACK_LABEL = NoteNatureLabel(NoteNatureType.GENERAL_NOTE, NoteNatureType.GENERAL_NOTE.humanReadable)
+        private val FALLBACK_LABEL = NoteNatureLabel(
+            NoteNatureType.GENERAL_NOTE,
+            NoteNatureType.GENERAL_NOTE.humanReadable,
+            0.0
+        )
 
         private const val MIN_ABSOLUTE_SCORE = 2.0
         private const val MIN_RELATIVE_SCORE = 0.25
@@ -315,7 +320,8 @@ class NoteNatureClassifier {
  */
 data class NoteNatureLabel(
     val type: NoteNatureType,
-    val humanReadable: String
+    val humanReadable: String,
+    val confidence: Double
 )
 
 /**

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
@@ -20,12 +20,22 @@ class SummarizerFallbackTest {
             whenever(fetcher.ensureModels(any())).thenReturn(ModelFetcher.Result.Failure("fail to fetch"))
         }
         val debugMessages = mutableListOf<String>()
+        val classifier = object : NoteNatureClassifier() {
+            override suspend fun classify(text: String, event: NoteEvent?): NoteNatureLabel {
+                return NoteNatureLabel(
+                    NoteNatureType.GENERAL_NOTE,
+                    NoteNatureType.GENERAL_NOTE.humanReadable,
+                    confidence = 0.0
+                )
+            }
+        }
         val summarizer = Summarizer(
             context = context,
             fetcher = fetcher,
             spFactory = { throw AssertionError("tokenizer should not be created in fallback") },
             nativeLoader = { throw AssertionError("native loader should not be invoked in fallback") },
             interpreterFactory = { throw AssertionError("interpreter should not be created in fallback") },
+            classifierFactory = { classifier },
             logger = { _, _ -> },
             debugSink = { debugMessages.add(it) }
         )


### PR DESCRIPTION
## Summary
- load a configurable NoteNatureClassifier in Summarizer, short-circuiting summarize() to return a trimmed classifier label with confidence tracing
- expose trimToWordLimit/wordCount helpers and clean up resources when closing the classifier
- extend tests to cover classifier-based output and ensure fallbacks bypass the classifier

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d13dec28688320ab995947556d5338