### PR TITLE
Align fallback summaries with classifier labels

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -169,7 +169,7 @@ class NoteViewModel(
         val initialSummary = if (summarizerSource.isBlank()) {
             ""
         } else {
-            summarizer?.let { it.fallbackSummary(summarizerSource) } ?: summarizerSource.take(200)
+            summarizer?.let { it.fallbackSummary(summarizerSource, event) } ?: summarizerSource.take(200)
         }
         val note = Note(
             title = finalTitle,
@@ -238,7 +238,7 @@ class NoteViewModel(
             val initialSummary = if (summarizerSource.isBlank()) {
                 ""
             } else {
-                summarizer?.let { it.fallbackSummary(summarizerSource) } ?: summarizerSource.take(200)
+                summarizer?.let { it.fallbackSummary(summarizerSource, finalEvent) } ?: summarizerSource.take(200)
             }
             val updatedDate = finalEvent?.start ?: System.currentTimeMillis()
             val preparedImages = prepareImagesForStorage(images)

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import java.io.File
 import java.io.RandomAccessFile
@@ -29,7 +30,8 @@ class Summarizer(
     private val nativeLoader: (Context) -> Boolean = { NativeLibraryLoader.ensureTokenizer(it) },
     private val interpreterFactory: (MappedByteBuffer) -> LiteInterpreter = { TfLiteInterpreter.create(it) },
     private val logger: (String, Throwable) -> Unit = { msg, t -> Log.e("Summarizer", "summarizer: $msg", t) },
-    private val debugSink: (String) -> Unit = { msg -> Log.d("Summarizer", "summarizer: $msg") }
+    private val debugSink: (String) -> Unit = { msg -> Log.d("Summarizer", "summarizer: $msg") },
+    private val classifier: NoteNatureClassifier = NoteNatureClassifier(),
 ) {
     private var encoder: LiteInterpreter? = null
     private var decoder: LiteInterpreter? = null
@@ -135,10 +137,11 @@ class Summarizer(
             val tok = tokenizer
 
             suspend fun fallback(reason: String, throwable: Throwable? = null): String {
-                emitDebug("fallback reason: $reason")
+                val label = classifyFallbackLabel(text, null)
+                emitDebug("fallback reason: $reason; classifier=${label.type}")
                 logger(reason, throwable ?: IllegalStateException(reason))
                 _state.emit(SummarizerState.Fallback)
-                return fallbackSummary(text)
+                return label.humanReadable
             }
 
             if (enc == null || dec == null || tok == null) {
@@ -376,81 +379,18 @@ class Summarizer(
         }
     }
 
-    fun fallbackSummary(text: String): String {
-        val sentences = extractSentences(text)
-        if (sentences.isEmpty()) {
-            emitDebug("fallback extractive summary using raw text due to missing sentences")
-            return text.take(200)
-        }
+    fun fallbackSummary(text: String): String = fallbackSummary(text, null)
 
-        val keywords = buildKeywordStats(text)
-        val candidates = sentences.mapIndexedNotNull { index, raw ->
-            val trimmed = raw.trim()
-            if (trimmed.isEmpty()) return@mapIndexedNotNull null
-            val words = tokenizeWords(trimmed)
-            val normalized = words.map { normalizeWord(it) }.filter { it.isNotEmpty() }
-            val keywordScore = if (keywords.isEmpty()) 0 else keywords.scoreNewWords(normalized)
-            val diversity = normalized.toSet().size.toDouble()
-            val lengthBonus = normalized.size.coerceAtMost(30) / 30.0
-            val letterBonus = if (words.any { containsLetter(it) }) 0.5 else 0.0
-            val score = keywordScore * 6.0 + diversity + lengthBonus + letterBonus
-            SentenceCandidate(trimmed, score, index)
-        }
-        if (candidates.isEmpty()) {
-            emitDebug("fallback extractive summary unable to score sentences")
-            return text.take(200)
-        }
-
-        val ranked = candidates.sortedWith(
-            compareByDescending<SentenceCandidate> { it.score }.thenBy { it.index }
-        )
-        val top = ranked.take(2).sortedBy { it.index }
-        if (top.isEmpty()) {
-            emitDebug("fallback extractive summary found no top sentences")
-            return text.take(200)
-        }
-
-        top.forEach {
-            emitDebug("fallback sentence[${it.index}] score=${"%.2f".format(it.score)} ${it.text}")
-        }
-
-        val summary = top.joinToString(" ") { candidate ->
-            val endsWithTerminator = candidate.text.lastOrNull()?.let { it in SENTENCE_ENDINGS } ?: false
-            if (endsWithTerminator) candidate.text else "${candidate.text}."
-        }
-        return if (summary.isNotBlank()) summary else text.take(200)
+    fun fallbackSummary(text: String, event: NoteEvent?): String {
+        val label = runBlocking { classifyFallbackLabel(text, event) }
+        return label.humanReadable
     }
 
-    private fun extractSentences(text: String): List<String> {
-        if (text.isBlank()) return emptyList()
-        val trimmed = text.trim()
-        val sentences = mutableListOf<String>()
-        val buffer = StringBuilder()
-        for (ch in trimmed) {
-            buffer.append(ch)
-            if (ch in SENTENCE_ENDINGS) {
-                val candidate = buffer.toString().trim()
-                if (candidate.isNotEmpty()) {
-                    sentences.add(candidate)
-                }
-                buffer.clear()
-            }
-        }
-        val remainder = buffer.toString().trim()
-        if (remainder.isNotEmpty()) {
-            sentences.add(remainder)
-        }
-        if (sentences.isEmpty()) {
-            return trimmed.lines().map { it.trim() }.filter { it.isNotEmpty() }
-        }
-        return sentences
+    private suspend fun classifyFallbackLabel(text: String, event: NoteEvent?): NoteNatureLabel {
+        val label = classifier.classify(text, event)
+        emitDebug("fallback classifier label: ${label.type} -> ${label.humanReadable}")
+        return label
     }
-
-    private data class SentenceCandidate(
-        val text: String,
-        val score: Double,
-        val index: Int,
-    )
 
     private fun selectNextToken(
         logits: FloatArray,

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -13,6 +13,7 @@ import org.junit.Before
 import org.junit.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
 import org.junit.Assert.assertEquals
 
@@ -33,7 +34,7 @@ class NoteViewModelTest {
     @Test
     fun addNoteUpdatesSummaryFromSummarizer() = runTest(dispatcher.scheduler) {
         val summarizer = mock<Summarizer>()
-        whenever(summarizer.fallbackSummary(any())).thenReturn("initial summary")
+        whenever(summarizer.fallbackSummary(any(), anyOrNull())).thenReturn(NoteNatureType.GENERAL_NOTE.humanReadable)
         whenever(summarizer.summarize(any())).thenReturn("mocked summary")
         whenever(summarizer.consumeDebugTrace()).thenReturn(emptyList())
 
@@ -41,6 +42,8 @@ class NoteViewModelTest {
         setField(viewModel, "summarizer", summarizer)
 
         viewModel.addNote("Title", "Content", emptyList(), emptyList(), emptyList())
+
+        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, viewModel.notes[0].summary)
 
         advanceUntilIdle()
 

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
@@ -3,7 +3,7 @@ package com.example.starbucknotetaker
 import android.content.Context
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
-import org.junit.Assert.assertFalse
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.any
@@ -13,7 +13,7 @@ import org.mockito.kotlin.whenever
 class SummarizerFallbackTest {
 
     @Test
-    fun fallbackTraceIncludesReasonAndSentences() = runTest {
+    fun fallbackTraceIncludesReasonAndClassifierCategory() = runTest {
         val context = mock<Context>()
         val fetcher = mock<ModelFetcher>()
         runBlocking {
@@ -33,20 +33,19 @@ class SummarizerFallbackTest {
         val source = "First sentence has coffee beans. Second sentence talks about roasting beans. Third sentence is ignored."
         val summary = summarizer.summarize(source)
 
-        assertFalse(summary.isBlank())
+        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, summary)
 
         val trace = summarizer.consumeDebugTrace()
         assertTrue(
             "Expected fallback reason to appear in trace, got: $trace",
-            trace.any { it.contains("fallback reason: models unavailable") }
+            trace.any { it.contains("fallback reason: models unavailable; classifier=GENERAL_NOTE") }
         )
         assertTrue(
-            "Expected fallback sentence log with actual text, got: $trace",
-            trace.any { it.contains("fallback sentence[0]") && it.contains("coffee beans") }
-        )
-        assertTrue(
-            "Expected fallback sentence log with actual text, got: $trace",
-            trace.any { it.contains("fallback sentence[1]") && it.contains("roasting beans") }
+            "Expected fallback classifier label to appear in trace, got: $trace",
+            trace.any {
+                it.contains("fallback classifier label: GENERAL_NOTE") &&
+                        it.contains(NoteNatureType.GENERAL_NOTE.humanReadable)
+            }
         )
     }
 }

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -30,12 +30,12 @@ class SummarizerTest {
     }
 
     @Test
-    fun fallbackSummaryPrefersHighScoringSentences() {
+    fun fallbackSummaryReturnsClassifierLabel() {
         val summarizer = Summarizer(context, nativeLoader = { false }, debugSink = { })
         val text = "Security updates require MFA for all accounts. Lunch options were discussed briefly. The security updates also add mandatory VPN use."
         val summary = summarizer.fallbackSummary(text)
         assertEquals(
-            "Security updates require MFA for all accounts. The security updates also add mandatory VPN use.",
+            NoteNatureType.GENERAL_NOTE.humanReadable,
             summary
         )
     }
@@ -56,7 +56,7 @@ class SummarizerTest {
 
         val text = "One. Two. Three."
         val result = summarizer.summarize(text)
-        assertEquals("One. Two.", result)
+        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- replace the extractive fallback in `Summarizer` with classifier labels and log the chosen category
- use the new classifier-backed fallback summary for optimistic updates in `NoteViewModel`
- update the summarizer and view model unit tests to expect classifier labels and the new debug trace entries

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d145e590548320ac63bd4c8842fc21