### PR TITLE
Fix navigation after biometric unlock

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -226,7 +226,6 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
     val summarizerState by noteViewModel.summarizerState.collectAsState()
     val pendingShare by noteViewModel.pendingShare.collectAsState()
     val pendingOpenNoteId by noteViewModel.pendingOpenNoteId.collectAsState()
-    val noteIdToOpenAfterUnlock by noteViewModel.noteIdToOpenAfterUnlock.collectAsState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val isPinSet = pinManager.isPinSet()
     var hasLoadedInitialPin by remember { mutableStateOf(false) }
@@ -258,7 +257,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 noteViewModel.markNoteTemporarilyUnlocked(request.noteId)
                 noteViewModel.clearBiometricUnlockRequest()
                 noteViewModel.clearPendingOpenNoteId()
-                noteViewModel.setNoteIdToOpenAfterUnlock(request.noteId)
+                openNoteAfterUnlock(request.noteId)
             }
 
             override fun onAuthenticationError(errorCode: Int, errString: CharSequence) {
@@ -366,12 +365,6 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 pendingBiometricOptIn = false
             }
         }
-    }
-
-    LaunchedEffect(noteIdToOpenAfterUnlock) {
-        val noteId = noteIdToOpenAfterUnlock ?: return@LaunchedEffect
-        openNoteAfterUnlock(noteId)
-        noteViewModel.clearNoteIdToOpenAfterUnlock()
     }
 
     LaunchedEffect(noteViewModel) {
@@ -594,7 +587,7 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                 onPinConfirmed = {
                     noteViewModel.markNoteTemporarilyUnlocked(noteId)
                     noteViewModel.clearPendingOpenNoteId()
-                    noteViewModel.setNoteIdToOpenAfterUnlock(noteId)
+                    openNoteAfterUnlock(noteId)
                 }
             )
         } else {

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -59,8 +59,6 @@ class NoteViewModel(
     val biometricUnlockRequest: StateFlow<BiometricUnlockRequest?> = _biometricUnlockRequest
     val pendingOpenNoteId: StateFlow<Long?> =
         savedStateHandle.getStateFlow(PENDING_OPEN_NOTE_ID_KEY, null)
-    val noteIdToOpenAfterUnlock: StateFlow<Long?> =
-        savedStateHandle.getStateFlow(NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY, null)
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -135,17 +133,8 @@ class NoteViewModel(
         savedStateHandle[PENDING_OPEN_NOTE_ID_KEY] = null
     }
 
-    fun setNoteIdToOpenAfterUnlock(noteId: Long) {
-        savedStateHandle[NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY] = noteId
-    }
-
-    fun clearNoteIdToOpenAfterUnlock() {
-        savedStateHandle[NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY] = null
-    }
-
     private companion object {
         const val PENDING_OPEN_NOTE_ID_KEY = "pending_open_note_id"
-        const val NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY = "note_id_to_open_after_unlock"
     }
 
     fun addNote(


### PR DESCRIPTION
## Summary
- open unlocked notes immediately after biometric or PIN authentication
- simplify unlock flow by removing unused noteIdToOpenAfterUnlock state

## Testing
- ./gradlew test *(fails: SummarizerTest assertions present on main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68d1510f62908320a034a9be1be47a3f