### PR TITLE
Restore lifecycle-aware biometric unlock navigation

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -32,6 +32,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.lifecycle.withResumed
 import com.example.starbucknotetaker.ui.AddNoteScreen
 import com.example.starbucknotetaker.ui.NoteEntryMode
 import com.example.starbucknotetaker.ui.NoteDetailScreen
@@ -370,8 +371,10 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
 
     LaunchedEffect(noteIdToOpenAfterUnlock) {
         val noteId = noteIdToOpenAfterUnlock ?: return@LaunchedEffect
-        openNoteAfterUnlock(noteId)
-        noteViewModel.clearNoteIdToOpenAfterUnlock()
+        activity.lifecycle.withResumed {
+            openNoteAfterUnlock(noteId)
+            noteViewModel.clearNoteIdToOpenAfterUnlock()
+        }
     }
 
     LaunchedEffect(noteViewModel) {

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class NoteViewModelTest {
@@ -50,9 +51,41 @@ class NoteViewModelTest {
         assertEquals("mocked summary", viewModel.notes[0].summary)
     }
 
+    @Test
+    fun noteIdToOpenAfterUnlockRoundTripInSavedState() {
+        val key = getStaticStringField("NOTE_ID_TO_OPEN_AFTER_UNLOCK_KEY")
+        val savedState = SavedStateHandle()
+        val viewModel = NoteViewModel(savedState)
+
+        assertNull(viewModel.noteIdToOpenAfterUnlock.value)
+        assertNull(savedState.get<Long?>(key))
+
+        viewModel.setNoteIdToOpenAfterUnlock(72L)
+
+        assertEquals(72L, viewModel.noteIdToOpenAfterUnlock.value)
+        assertEquals(72L, savedState.get<Long?>(key))
+
+        val restored = NoteViewModel(SavedStateHandle(mapOf(key to 72L)))
+
+        assertEquals(72L, restored.noteIdToOpenAfterUnlock.value)
+
+        restored.clearNoteIdToOpenAfterUnlock()
+        assertNull(restored.noteIdToOpenAfterUnlock.value)
+
+        viewModel.clearNoteIdToOpenAfterUnlock()
+        assertNull(viewModel.noteIdToOpenAfterUnlock.value)
+        assertNull(savedState.get<Long?>(key))
+    }
+
     private fun setField(target: Any, name: String, value: Any?) {
         val field = target.javaClass.getDeclaredField(name)
         field.isAccessible = true
         field.set(target, value)
+    }
+
+    private fun getStaticStringField(name: String): String {
+        val field = NoteViewModel::class.java.getDeclaredField(name)
+        field.isAccessible = true
+        return field.get(null) as String
     }
 }


### PR DESCRIPTION
## Summary
- persist the note id that should open after authentication in `NoteViewModel` so the UI can react once the activity resumes
- trigger navigation from a lifecycle-aware effect using `withResumed` for both biometric and PIN unlock flows instead of navigating inside prompt callbacks
- cover the saved-state round trip for the unlock navigation id with a unit test to guard against regressions

## Testing
- ./gradlew test *(fails: existing `SummarizerTest` assertions still failing on main branch)*

------
https://chatgpt.com/codex/tasks/task_e_68d1510f62908320a034a9be1be47a3f