### PR TITLE
Fix biometric unlock navigation flow

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -59,6 +59,8 @@ class NoteViewModel(
     val biometricUnlockRequest: StateFlow<BiometricUnlockRequest?> = _biometricUnlockRequest
     val pendingOpenNoteId: StateFlow<Long?> =
         savedStateHandle.getStateFlow(PENDING_OPEN_NOTE_ID_KEY, null)
+    val pendingUnlockNavigationNoteId: StateFlow<Long?> =
+        savedStateHandle.getStateFlow(PENDING_UNLOCK_NAVIGATION_NOTE_ID_KEY, null)
 
     fun loadNotes(context: Context, pin: String) {
         this.pin = pin
@@ -133,8 +135,17 @@ class NoteViewModel(
         savedStateHandle[PENDING_OPEN_NOTE_ID_KEY] = null
     }
 
+    fun setPendingUnlockNavigationNoteId(noteId: Long) {
+        savedStateHandle[PENDING_UNLOCK_NAVIGATION_NOTE_ID_KEY] = noteId
+    }
+
+    fun clearPendingUnlockNavigationNoteId() {
+        savedStateHandle[PENDING_UNLOCK_NAVIGATION_NOTE_ID_KEY] = null
+    }
+
     private companion object {
         const val PENDING_OPEN_NOTE_ID_KEY = "pending_open_note_id"
+        const val PENDING_UNLOCK_NAVIGATION_NOTE_ID_KEY = "pending_unlock_navigation_note_id"
     }
 
     fun addNote(

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -50,6 +50,23 @@ class NoteViewModelTest {
         assertEquals("mocked summary", viewModel.notes[0].summary)
     }
 
+    @Test
+    fun pendingUnlockNavigationNoteIdPersistsAcrossSavedState() = runTest(dispatcher.scheduler) {
+        val handle = SavedStateHandle()
+        val viewModel = NoteViewModel(handle)
+
+        viewModel.setPendingUnlockNavigationNoteId(123L)
+        assertEquals(123L, viewModel.pendingUnlockNavigationNoteId.value)
+
+        val restoredHandle = SavedStateHandle(handle.keys().associateWith { key -> handle.get<Any?>(key) })
+        val restoredViewModel = NoteViewModel(restoredHandle)
+
+        assertEquals(123L, restoredViewModel.pendingUnlockNavigationNoteId.value)
+
+        restoredViewModel.clearPendingUnlockNavigationNoteId()
+        assertEquals(null, restoredViewModel.pendingUnlockNavigationNoteId.value)
+    }
+
     private fun setField(target: Any, name: String, value: Any?) {
         val field = target.javaClass.getDeclaredField(name)
         field.isAccessible = true


### PR DESCRIPTION
## Summary
- queue biometric and PIN unlock navigation so it runs after authentication when the UI is resumed
- persist the pending unlock navigation id in NoteViewModel's SavedStateHandle
- cover the saved-state round trip for the unlock navigation id with a unit test

## Testing
- ./gradlew test *(fails: SummarizerTest summarizeReturnsClassifierLabelWithinWordLimit, summarizePrefersNoteKeywordsOverGenericOpeners, summarizeKeepsHyphenatedParaphrase)*

------
https://chatgpt.com/codex/tasks/task_e_68d15b51c994832085e05d15ec05eba1