### PR TITLE
Handle pending unlock navigation via activity lifecycle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -167,6 +167,7 @@ dependencies {
     testImplementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     testImplementation 'org.json:json:20240303'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+    testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation platform('androidx.compose:compose-bom:2024.06.00')

--- a/app/src/test/java/com/example/starbucknotetaker/PendingUnlockNavigationTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/PendingUnlockNavigationTest.kt
@@ -1,0 +1,70 @@
+package com.example.starbucknotetaker
+
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.testing.TestLifecycleOwner
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PendingUnlockNavigationTest {
+    @Test
+    fun pendingUnlockNavigationClearsIdAndNavigatesAgainAfterCancellation() {
+        runTest {
+            val dispatcher = StandardTestDispatcher(testScheduler)
+            Dispatchers.setMain(dispatcher)
+            try {
+                val lifecycleOwner = TestLifecycleOwner(Lifecycle.State.RESUMED)
+                val viewModel = NoteViewModel(SavedStateHandle())
+                val noteId = 42L
+
+                viewModel.setPendingUnlockNavigationNoteId(noteId)
+                var navigationCount = 0
+
+                val cancelledNavigation = launch {
+                    try {
+                        navigatePendingUnlock(
+                            lifecycle = lifecycleOwner.lifecycle,
+                            noteViewModel = viewModel,
+                            noteId = noteId,
+                            openNoteAfterUnlock = {
+                                navigationCount++
+                                throw CancellationException("Simulated navigation cancellation")
+                            },
+                        )
+                    } catch (_: CancellationException) {
+                        // Expected due to the simulated cancellation above.
+                    }
+                }
+
+                cancelledNavigation.join()
+
+                assertEquals(1, navigationCount)
+                assertNull(viewModel.pendingUnlockNavigationNoteId.value)
+
+                viewModel.setPendingUnlockNavigationNoteId(noteId)
+
+                navigatePendingUnlock(
+                    lifecycle = lifecycleOwner.lifecycle,
+                    noteViewModel = viewModel,
+                    noteId = noteId,
+                    openNoteAfterUnlock = { navigationCount++ },
+                )
+
+                assertEquals(2, navigationCount)
+                assertNull(viewModel.pendingUnlockNavigationNoteId.value)
+            } finally {
+                Dispatchers.resetMain()
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- run pending unlock navigation work on the activity lifecycle and always clear the pending id afterwards
- expose a reusable navigatePendingUnlock helper and drop the LocalLifecycleOwner dependency in AppContent
- add lifecycle-runtime-testing for unit tests and cover repeated unlock navigation in PendingUnlockNavigationTest

## Testing
- ./gradlew testDebugUnitTest --tests PendingUnlockNavigationTest --console=plain
- ./gradlew testReleaseUnitTest --tests PendingUnlockNavigationTest --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d16a331adc8320a9163ac28d3e82f7