### PR TITLE
Fix biometric unlock request token property

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
@@ -1,3 +1,12 @@
 package com.example.starbucknotetaker
 
-data class BiometricUnlockRequest(val noteId: Long, val title: String)
+/**
+ * Represents a biometric unlock request for a note. The [token] property defaults to a
+ * unique value so that repeated requests for the same note still trigger the biometric
+ * prompt.
+ */
+data class BiometricUnlockRequest(
+    val noteId: Long,
+    val title: String,
+    val token: Long = System.nanoTime(),
+)


### PR DESCRIPTION
## Summary
- add a unique token field to `BiometricUnlockRequest` so biometric prompts retrigger for the same note
- document the purpose of the token field

## Testing
- ./gradlew compileDebugKotlin --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d176e100b88320989615f65f7260db