### PR TITLE
Improve biometric unlock flow and diagnostics

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/BiometricUnlockRequest.kt
@@ -1,5 +1,7 @@
 package com.example.starbucknotetaker
 
+const val BIOMETRIC_LOG_TAG = "BiometricFlow"
+
 /**
  * Represents a biometric unlock request for a note. The [token] property defaults to a
  * unique value so that repeated requests for the same note still trigger the biometric


### PR DESCRIPTION
## Summary
- add a shared flow for biometric unlock requests along with a reusable log tag
- instrument biometric request, authentication callbacks, navigation, and PIN prompt paths with detailed logging
- trigger authentication via a dedicated event counter and route unlocks through pending navigation so notes open reliably after success

## Testing
- ./gradlew clean test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d1ba63d92c8320a9d14e2b1ea598c1