### PR TITLE
Handle null pending unlock state

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/PendingUnlockNavigation.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PendingUnlockNavigation.kt
@@ -19,7 +19,7 @@ suspend fun navigatePendingUnlock(
     logPendingUnlock(
         "navigatePendingUnlock start noteId=${'$'}noteId pendingId=${'$'}pendingId lifecycle=${'$'}{lifecycle.currentState}"
     )
-    if (pendingId != noteId) {
+    if (pendingId != null && pendingId != noteId) {
         logPendingUnlock(
             "navigatePendingUnlock skip_initial_mismatch noteId=${'$'}noteId pendingId=${'$'}pendingId lifecycle=${'$'}{lifecycle.currentState}"
         )


### PR DESCRIPTION
## Summary
- relax the initial pending unlock comparison so null snapshots no longer abort navigation
- add a unit test that simulates a transient null before resuming and confirms navigation still occurs

## Testing
- ./gradlew --console=plain test

------
https://chatgpt.com/codex/tasks/task_e_68d1e2fc3a5c8320a86f91048b11af8c