### PR TITLE
Guard biometric opt-in during unlock

### DIFF
--- a/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
@@ -16,6 +16,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class BiometricNavigationTest {
@@ -76,7 +77,9 @@ class BiometricNavigationTest {
                 .fetchSemanticsNodes().isNotEmpty()
         }
 
-        BiometricPromptTestHooks.interceptAuthenticate = { _, callback ->
+        BiometricPromptTestHooks.interceptAuthenticate = { promptInfo, callback ->
+            val title = promptInfo.title.toString()
+            assertEquals("Unlock note", title)
             callback.onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult(null))
             true
         }


### PR DESCRIPTION
## Summary
- add explicit helpers to manage pending biometric opt-in state and clear it before launching unlock prompts
- log opt-in prompt launches and enforce that unlock requests occur only when no opt-in confirmation is pending
- extend biometric navigation instrumentation test to assert that locked note taps launch the unlock prompt title

## Testing
- ./gradlew test --no-daemon --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d27ccf080c8320a1b7f14dacb00577