### PR TITLE
Improve biometric prompt guard logging

### DIFF
--- a/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
@@ -77,8 +77,10 @@ class BiometricNavigationTest {
                 .fetchSemanticsNodes().isNotEmpty()
         }
 
+        val launchedPrompts = mutableListOf<String>()
         BiometricPromptTestHooks.interceptAuthenticate = { promptInfo, callback ->
             val title = promptInfo.title.toString()
+            launchedPrompts += title
             assertEquals("Unlock note", title)
             callback.onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult(null))
             true
@@ -93,5 +95,6 @@ class BiometricNavigationTest {
         }
 
         composeTestRule.onNodeWithText(content).assertIsDisplayed()
+        assertEquals(listOf("Unlock note"), launchedPrompts)
     }
 }


### PR DESCRIPTION
## Summary
- add detailed logging around the biometric opt-in prompt and ensure the pending flag is only cleared from the callback
- guard biometric unlock launches while an opt-in prompt is pending and log when suppressing an unlock request
- extend the biometric navigation instrumentation test to confirm only the unlock prompt is launched for locked notes

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d28fc136708320b3667addbef3c2e8