### PR TITLE
Format event location summary lines

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -571,7 +571,12 @@ private fun buildEventSummary(event: NoteEvent): String {
             }
         }
         event.location?.takeIf { it.isNotBlank() }?.let { location ->
-            appendLine("Location: $location")
+            val display = fallbackEventLocationDisplay(location)
+            val name = display.name.takeIf { it.isNotBlank() } ?: location.trim()
+            appendLine("Location: $name")
+            display.address
+                ?.takeUnless { it.isBlank() || it.equals(name, ignoreCase = true) }
+                ?.let { appendLine(it) }
         }
         event.reminderMinutesBeforeStart?.let { minutes ->
             appendLine("Reminder: ${formatReminderOffsetMinutes(minutes)}")

--- a/app/src/test/java/com/example/starbucknotetaker/ui/NoteDetailScreenTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/ui/NoteDetailScreenTest.kt
@@ -1,0 +1,81 @@
+package com.example.starbucknotetaker.ui
+
+import com.example.starbucknotetaker.Note
+import com.example.starbucknotetaker.NoteEvent
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.lang.reflect.Method
+
+class NoteDetailScreenTest {
+
+    @Test
+    fun `event summary splits location into name and address`() {
+        val event = NoteEvent(
+            start = 1_700_000_000_000,
+            end = 1_700_000_360_000,
+            allDay = false,
+            timeZone = "UTC",
+            location = "Melkweg\nLijnbaansgracht 234A, Amsterdam",
+            reminderMinutesBeforeStart = null,
+        )
+
+        val summary = invokeBuildEventSummary(event)
+        val lines = summary.lines()
+        val locationIndex = lines.indexOfFirst { it.startsWith("Location:") }
+        assertTrue("Location line not found in summary: $summary", locationIndex >= 0)
+        assertEquals("Location: Melkweg", lines[locationIndex])
+        assertTrue(
+            "Expected address line after location but was: ${lines.getOrNull(locationIndex + 1)}",
+            lines.getOrNull(locationIndex + 1)?.trim() == "Lijnbaansgracht 234A, Amsterdam"
+        )
+    }
+
+    @Test
+    fun `share text uses formatted event summary`() {
+        val event = NoteEvent(
+            start = 1_700_000_000_000,
+            end = 1_700_000_360_000,
+            allDay = false,
+            timeZone = "UTC",
+            location = "Melkweg\nLijnbaansgracht 234A, Amsterdam",
+            reminderMinutesBeforeStart = null,
+        )
+        val note = Note(
+            title = "Concert",
+            content = "",
+            event = event,
+        )
+
+        val shareText = invokeBuildShareText(note)
+
+        assertTrue(
+            "Share text should contain the formatted location",
+            shareText.contains("Location: Melkweg\nLijnbaansgracht 234A, Amsterdam")
+        )
+    }
+
+    private fun invokeBuildEventSummary(event: NoteEvent): String {
+        val method = buildEventSummaryMethod
+        return method.invoke(null, event) as String
+    }
+
+    private fun invokeBuildShareText(note: Note): String {
+        val method = buildShareTextMethod
+        return method.invoke(null, note) as String
+    }
+
+    private val buildEventSummaryMethod: Method by lazy {
+        val clazz = Class.forName("com.example.starbucknotetaker.ui.NoteDetailScreenKt")
+        clazz.getDeclaredMethod("buildEventSummary", NoteEvent::class.java).apply {
+            isAccessible = true
+        }
+    }
+
+    private val buildShareTextMethod: Method by lazy {
+        val clazz = Class.forName("com.example.starbucknotetaker.ui.NoteDetailScreenKt")
+        clazz.getDeclaredMethod("buildShareText", Note::class.java).apply {
+            isAccessible = true
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- derive the event location display using the existing fallback helper so summaries separate primary names from full addresses
- keep the share text aligned with the updated event summary formatting while avoiding duplicated address lines
- add unit coverage that reflects private summary builders to confirm a multiline location yields name and address lines

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d2953fa4348320acae4ab46ca8d633