### PR TITLE
Fix biometric opt-in clearing retrigger

### DIFF
--- a/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
@@ -4,11 +4,14 @@ import android.content.Context
 import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricPrompt
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsOff
+import androidx.compose.ui.test.assertIsOn
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onAllNodesWithContentDescription
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.performClick
 import androidx.compose.ui.test.performTextInput
 import androidx.test.core.app.ApplicationProvider
@@ -19,6 +22,7 @@ import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 
 @RunWith(AndroidJUnit4::class)
 class BiometricNavigationTest {
@@ -165,5 +169,147 @@ class BiometricNavigationTest {
         }
         composeTestRule.onNodeWithText(noteContent).assertIsDisplayed()
         assertEquals(listOf("Enable biometric unlock", "Unlock note"), launchedPrompts)
+    }
+
+    @Test
+    fun biometricUnlockPromptDoesNotRetriggerWhenOptInInactive() {
+        val prefs = context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
+        prefs.edit().clear().commit()
+        context.getFileStreamPath("notes.enc")?.delete()
+
+        composeTestRule.activityRule.scenario.recreate()
+
+        val launchedPrompts = mutableListOf<String>()
+        val biometricLogs = mutableListOf<String>()
+
+        BiometricPromptTestHooks.interceptAuthenticate = { promptInfo, callback ->
+            val title = promptInfo.title.toString()
+            launchedPrompts += title
+            when (title) {
+                "Enable biometric unlock",
+                "Disable biometric unlock",
+                "Unlock note" -> {
+                    callback.onAuthenticationSucceeded(BiometricPrompt.AuthenticationResult(null))
+                    true
+                }
+                else -> false
+            }
+        }
+        BiometricPromptTestHooks.logListener = { message ->
+            if (
+                message.contains("clearPendingBiometricOptIn") ||
+                message.contains("biometric unlock request suppressed") ||
+                message.contains("Launching biometric prompt")
+            ) {
+                biometricLogs += message
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasSetTextAction()).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNode(hasSetTextAction()).performTextInput("1234")
+        composeTestRule.onNodeWithText("Next").performClick()
+        composeTestRule.onNode(hasSetTextAction()).performTextInput("1234")
+        composeTestRule.onNodeWithText("Save").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Enable biometric unlock?").fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText("Enable").performClick()
+
+        val noteTitle = "Loop guard note"
+        val noteContent = "Loop guard content"
+
+        composeTestRule.activityRule.scenario.onActivity { activity ->
+            val viewModel = activity.getNoteViewModelForTest()
+            viewModel.addNote(
+                title = noteTitle,
+                content = noteContent,
+                images = emptyList(),
+                files = emptyList(),
+                linkPreviews = emptyList(),
+                event = null,
+            )
+            val noteId = viewModel.notes.first { it.title == noteTitle }.id
+            viewModel.setNoteLock(noteId, true)
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText(noteTitle).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(noteTitle).performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText(noteContent).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(noteContent).assertIsDisplayed()
+
+        assertEquals(listOf("Enable biometric unlock", "Unlock note"), launchedPrompts)
+
+        val noteListLogs = biometricLogs.filter { it.contains("reason=note_list_unlock_request") }
+        assertTrue(noteListLogs.isNotEmpty())
+        assertTrue(noteListLogs.all { it.contains("action=idle") })
+
+        val launchLogs = biometricLogs.filter { it.contains("Launching biometric prompt noteId") }
+        assertTrue(launchLogs.isNotEmpty())
+        assertTrue(launchLogs.last().contains("pendingOptIn=false"))
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithContentDescription("Settings").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithContentDescription("Settings").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText("Settings").fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("biometric_toggle").assertIsOn()
+        composeTestRule.onNodeWithTag("biometric_toggle").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            launchedPrompts.contains("Disable biometric unlock")
+        }
+        composeTestRule.onNodeWithTag("biometric_toggle").assertIsOff()
+
+        composeTestRule.onNodeWithTag("biometric_toggle").performClick()
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            launchedPrompts.count { it == "Enable biometric unlock" } >= 2
+        }
+        composeTestRule.onNodeWithTag("biometric_toggle").assertIsOn()
+
+        composeTestRule.onNodeWithContentDescription("Back").performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText(noteTitle).fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText(noteTitle).performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodesWithText(noteContent).fetchSemanticsNodes().isNotEmpty()
+        }
+        composeTestRule.onNodeWithText(noteContent).assertIsDisplayed()
+
+        val expectedPrompts = listOf(
+            "Enable biometric unlock",
+            "Unlock note",
+            "Disable biometric unlock",
+            "Enable biometric unlock",
+            "Unlock note",
+        )
+        assertEquals(expectedPrompts, launchedPrompts)
+
+        val noteListLogsAfterToggle = biometricLogs.filter { it.contains("reason=note_list_unlock_request") }
+        assertEquals(2, noteListLogsAfterToggle.size)
+        noteListLogsAfterToggle.forEach { log ->
+            assertTrue(log.contains("action=idle"))
+        }
+
+        val launchLogsAfterToggle = biometricLogs.filter { it.contains("Launching biometric prompt noteId") }
+        assertTrue(launchLogsAfterToggle.takeLast(2).all { it.contains("pendingOptIn=false") })
+        assertTrue(biometricLogs.none { it.contains("biometric unlock request suppressed") })
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/BiometricPromptTestHooks.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/BiometricPromptTestHooks.kt
@@ -13,9 +13,17 @@ object BiometricPromptTestHooks {
     @Volatile
     var overrideCanAuthenticate: Int? = null
 
+    @Volatile
+    var logListener: ((String) -> Unit)? = null
+
+    fun notifyBiometricLog(message: String) {
+        logListener?.invoke(message)
+    }
+
     @VisibleForTesting
     fun reset() {
         interceptAuthenticate = null
         overrideCanAuthenticate = null
+        logListener = null
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -245,20 +245,28 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         val previous = pendingBiometricOptIn
         val triggerBefore = biometricPromptTrigger
         val pendingRequest = noteViewModel.currentBiometricUnlockRequest()
+        val activeRequestToken = biometricUnlockRequest?.token
+        val matchesCurrentFlow = pendingRequest != null && activeRequestToken != null && pendingRequest.token == activeRequestToken
         pendingBiometricOptIn = false
         val pendingAfter = pendingBiometricOptIn
-        if (pendingRequest != null) {
+        if (previous && pendingRequest != null && matchesCurrentFlow) {
             val triggerAfter = triggerBefore + 1
             biometricPromptTrigger = triggerAfter
+            val logMessage =
+                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=$pendingAfter requestNoteId=${pendingRequest.noteId} requestToken=${pendingRequest.token} activeToken=$activeRequestToken matchesCurrentFlow=$matchesCurrentFlow triggerBefore=$triggerBefore triggerAfter=$triggerAfter action=retrigger"
             Log.d(
                 BIOMETRIC_LOG_TAG,
-                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=$pendingAfter requestNoteId=${pendingRequest.noteId} requestToken=${pendingRequest.token} triggerBefore=$triggerBefore triggerAfter=$triggerAfter action=retrigger"
+                logMessage
             )
+            BiometricPromptTestHooks.notifyBiometricLog(logMessage)
         } else {
+            val logMessage =
+                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=$pendingAfter requestNoteId=${pendingRequest?.noteId} requestToken=${pendingRequest?.token} activeToken=$activeRequestToken matchesCurrentFlow=$matchesCurrentFlow triggerBefore=$triggerBefore action=idle"
             Log.d(
                 BIOMETRIC_LOG_TAG,
-                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=$pendingAfter requestNoteId=null requestToken=null triggerBefore=$triggerBefore action=idle"
+                logMessage
             )
+            BiometricPromptTestHooks.notifyBiometricLog(logMessage)
         }
     }
 
@@ -462,16 +470,22 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
         if (biometricPromptTrigger == 0L) return@LaunchedEffect
         val request = biometricUnlockRequest ?: return@LaunchedEffect
         if (pendingBiometricOptIn) {
+            val logMessage =
+                "biometric unlock request suppressed noteId=${'$'}{request.noteId} token=${'$'}{request.token} trigger=${'$'}biometricPromptTrigger pendingOptIn=true"
             Log.w(
                 BIOMETRIC_LOG_TAG,
-                "biometric unlock request suppressed noteId=${'$'}{request.noteId} token=${'$'}{request.token} trigger=${'$'}biometricPromptTrigger pendingOptIn=true"
+                logMessage
             )
+            BiometricPromptTestHooks.notifyBiometricLog(logMessage)
             return@LaunchedEffect
         }
+        val logMessage =
+            "Launching biometric prompt noteId=${'$'}{request.noteId} token=${'$'}{request.token} trigger=${'$'}biometricPromptTrigger pendingOptIn=${'$'}pendingBiometricOptIn"
         Log.d(
             BIOMETRIC_LOG_TAG,
-            "Launching biometric prompt noteId=${'$'}{request.noteId} token=${'$'}{request.token} trigger=${'$'}biometricPromptTrigger} pendingOptIn=${'$'}pendingBiometricOptIn"
+            logMessage
         )
+        BiometricPromptTestHooks.notifyBiometricLog(logMessage)
         launchedBiometricRequest.value = request
         val promptInfo = BiometricPrompt.PromptInfo.Builder()
             .setTitle("Unlock note")

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.testTag
 import androidx.core.content.ContextCompat
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.PinManager
@@ -287,6 +288,7 @@ fun SettingsScreen(
                         )
                     }
                     Switch(
+                        modifier = Modifier.testTag("biometric_toggle"),
                         checked = biometricChecked,
                         onCheckedChange = { checked ->
                             if (biometricInProgress) return@Switch


### PR DESCRIPTION
## Summary
- gate `clearPendingBiometricOptIn` retriggers on active opt-in requests and expose biometric logs to test hooks
- surface BIOMETRIC_LOG_TAG diagnostics when launching prompts and tag the settings toggle for instrumentation
- add an instrumentation test that covers enabling biometrics, toggling them in settings, and unlocking notes without stale retriggers

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d2befddfa08320b4c8374df2576c3c