### PR TITLE
Ensure biometric opt-in flag clears on token mismatch

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -281,9 +281,10 @@ fun AppContent(navController: NavHostController, noteViewModel: NoteViewModel, p
                     pendingBiometricOptIn = false
                     "idle"
                 } else {
+                    pendingBiometricOptIn = false
                     when {
-                        activeRequestToken == null -> "left_pending_missing_active_token"
-                        else -> "left_pending_token_mismatch"
+                        activeRequestToken == null -> "force_clear_missing_active_token"
+                        else -> "force_clear_token_mismatch"
                     }
                 }
             } else {


### PR DESCRIPTION
## Summary
- explicitly clear pendingBiometricOptIn when active tokens are missing or mismatched and log the branch for diagnostics
- retain BiometricPromptTestHooks logging so test hooks observe the new actions

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68d30807acfc8320a420fd79292fe443