### PR TITLE
Refactor biometric opt-in guard

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/BiometricOptInReplayGuard.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/BiometricOptInReplayGuard.kt
@@ -1,0 +1,135 @@
+package com.example.starbucknotetaker
+
+import androidx.compose.runtime.LongState
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.mutableStateOf
+
+/**
+ * Maintains the biometric opt-in replay guard state and logging side effects.
+ */
+class BiometricOptInReplayGuard(
+    private val logger: (String) -> Unit,
+    private val notifyBiometricLog: (String) -> Unit,
+    private val currentBiometricUnlockRequest: () -> BiometricUnlockRequest?,
+    private val currentActiveRequestToken: () -> Long?,
+    private val isGuardDisabled: () -> Boolean = { BiometricPromptTestHooks.disableOptInReplayGuard },
+) {
+    private val _pendingOptIn = mutableStateOf(false)
+    val pendingOptIn: State<Boolean> = _pendingOptIn
+
+    private val _promptTrigger = mutableLongStateOf(0L)
+    val promptTrigger: LongState = _promptTrigger
+
+    enum class ClearAction {
+        RETRIGGER,
+        IDLE,
+        FORCE_CLEAR_MISSING_ACTIVE_TOKEN,
+        FORCE_CLEAR_TOKEN_MISMATCH,
+        NOOP,
+    }
+
+    data class ClearResult(
+        val action: ClearAction,
+        val pendingOptIn: Boolean,
+        val promptTrigger: Long,
+        val matchesCurrentFlow: Boolean,
+        val hasActiveFlow: Boolean,
+    )
+
+    fun confirmPendingOptIn(reason: String) {
+        check(!_pendingOptIn.value) {
+            "confirmPendingOptIn while pending"
+        }
+        _pendingOptIn.value = true
+        log("confirmPendingBiometricOptIn reason=$reason")
+    }
+
+    fun clearPendingOptIn(reason: String): ClearResult {
+        val previous = _pendingOptIn.value
+        val triggerBefore = _promptTrigger.longValue
+        val pendingRequest = currentBiometricUnlockRequest()
+        val activeRequestToken = currentActiveRequestToken()
+        val matchesCurrentFlow =
+            pendingRequest != null && activeRequestToken != null && pendingRequest.token == activeRequestToken
+
+        if (
+            previous &&
+            (reason == "note_list_unlock_request" || reason == "pin_prompt_biometric_request")
+        ) {
+            val guardLog =
+                "biometricOptInReplayGuard reason=$reason previous=$previous requestNoteId=${pendingRequest?.noteId} " +
+                    "requestToken=${pendingRequest?.token} activeToken=$activeRequestToken matchesCurrentFlow=$matchesCurrentFlow " +
+                    "triggerBefore=$triggerBefore action=observe"
+            log(guardLog)
+        }
+
+        val hasActiveFlow = previous && pendingRequest != null
+        val guardDisabled = isGuardDisabled()
+        val shouldRetrigger = hasActiveFlow && matchesCurrentFlow && !guardDisabled
+        val action: ClearAction
+
+        if (shouldRetrigger) {
+            val currentRequest = checkNotNull(pendingRequest)
+            _pendingOptIn.value = false
+            val triggerAfter = triggerBefore + 1
+            _promptTrigger.longValue = triggerAfter
+            action = ClearAction.RETRIGGER
+            val logMessage =
+                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=${_pendingOptIn.value} " +
+                    "requestNoteId=${currentRequest.noteId} requestToken=${currentRequest.token} activeToken=$activeRequestToken " +
+                    "matchesCurrentFlow=$matchesCurrentFlow triggerBefore=$triggerBefore triggerAfter=$triggerAfter action=retrigger"
+            log(logMessage)
+        } else {
+            val logAction = when {
+                hasActiveFlow -> {
+                    if (guardDisabled) {
+                        ClearAction.IDLE
+                    } else {
+                        when (activeRequestToken) {
+                            null -> ClearAction.FORCE_CLEAR_MISSING_ACTIVE_TOKEN
+                            else -> ClearAction.FORCE_CLEAR_TOKEN_MISMATCH
+                        }
+                    }
+                }
+                previous -> ClearAction.IDLE
+                else -> ClearAction.NOOP
+            }
+            action = logAction
+            _pendingOptIn.value = false
+            val logMessage =
+                "clearPendingBiometricOptIn reason=$reason previous=$previous pendingAfter=${_pendingOptIn.value} " +
+                    "requestNoteId=${pendingRequest?.noteId} requestToken=${pendingRequest?.token} activeToken=$activeRequestToken " +
+                    "matchesCurrentFlow=$matchesCurrentFlow triggerBefore=$triggerBefore action=${action.toLogValue()}"
+            log(logMessage)
+        }
+
+        return ClearResult(
+            action = action,
+            pendingOptIn = _pendingOptIn.value,
+            promptTrigger = _promptTrigger.longValue,
+            matchesCurrentFlow = matchesCurrentFlow,
+            hasActiveFlow = hasActiveFlow,
+        )
+    }
+
+    fun onBiometricUnlockEvent(): Long {
+        val nextTrigger = _promptTrigger.longValue + 1
+        _promptTrigger.longValue = nextTrigger
+        return nextTrigger
+    }
+
+    private fun log(message: String) {
+        logger(message)
+        notifyBiometricLog(message)
+    }
+
+    private fun ClearAction.toLogValue(): String =
+        when (this) {
+            ClearAction.RETRIGGER -> "retrigger"
+            ClearAction.IDLE -> "idle"
+            ClearAction.FORCE_CLEAR_MISSING_ACTIVE_TOKEN -> "force_clear_missing_active_token"
+            ClearAction.FORCE_CLEAR_TOKEN_MISMATCH -> "force_clear_token_mismatch"
+            ClearAction.NOOP -> "noop"
+        }
+}

--- a/app/src/test/java/com/example/starbucknotetaker/BiometricOptInReplayGuardTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/BiometricOptInReplayGuardTest.kt
@@ -1,0 +1,86 @@
+package com.example.starbucknotetaker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class BiometricOptInReplayGuardTest {
+
+    @Test
+    fun clearPendingOptIn_retriggers_whenFlowMatches() {
+        val logMessages = mutableListOf<String>()
+        val notifiedMessages = mutableListOf<String>()
+        val request = BiometricUnlockRequest(noteId = 1L, title = "Secret", token = 7L)
+        var currentRequest: BiometricUnlockRequest? = request
+        var activeToken: Long? = request.token
+        val guard = BiometricOptInReplayGuard(
+            logger = { logMessages += it },
+            notifyBiometricLog = { notifiedMessages += it },
+            currentBiometricUnlockRequest = { currentRequest },
+            currentActiveRequestToken = { activeToken },
+        )
+
+        guard.confirmPendingOptIn("opt_in_dialog_confirm")
+        val result = guard.clearPendingOptIn("note_list_unlock_request")
+
+        assertEquals(BiometricOptInReplayGuard.ClearAction.RETRIGGER, result.action)
+        assertEquals(1L, result.promptTrigger)
+        assertFalse(result.pendingOptIn)
+        assertTrue(result.matchesCurrentFlow)
+        assertTrue(result.hasActiveFlow)
+        assertTrue(logMessages.any { it.contains("action=observe") })
+        assertTrue(logMessages.any { it.contains("action=retrigger") })
+        assertTrue(notifiedMessages.any { it.contains("action=retrigger") })
+    }
+
+    @Test
+    fun clearPendingOptIn_idles_whenNoActiveRequest() {
+        val logMessages = mutableListOf<String>()
+        var currentRequest: BiometricUnlockRequest? = null
+        var activeToken: Long? = 99L
+        val guard = BiometricOptInReplayGuard(
+            logger = { logMessages += it },
+            notifyBiometricLog = {},
+            currentBiometricUnlockRequest = { currentRequest },
+            currentActiveRequestToken = { activeToken },
+        )
+
+        guard.confirmPendingOptIn("opt_in_dialog_confirm")
+        val result = guard.clearPendingOptIn("note_list_unlock_request")
+
+        assertEquals(BiometricOptInReplayGuard.ClearAction.IDLE, result.action)
+        assertEquals(0L, result.promptTrigger)
+        assertFalse(result.pendingOptIn)
+        assertFalse(result.hasActiveFlow)
+        assertTrue(logMessages.any { it.contains("action=idle") })
+    }
+
+    @Test
+    fun clearPendingOptIn_idles_whenGuardDisabled() {
+        val logMessages = mutableListOf<String>()
+        var currentRequest: BiometricUnlockRequest? = BiometricUnlockRequest(
+            noteId = 9L,
+            title = "Secret",
+            token = 11L,
+        )
+        var activeToken: Long? = currentRequest!!.token
+        var guardDisabled = true
+        val guard = BiometricOptInReplayGuard(
+            logger = { logMessages += it },
+            notifyBiometricLog = {},
+            currentBiometricUnlockRequest = { currentRequest },
+            currentActiveRequestToken = { activeToken },
+            isGuardDisabled = { guardDisabled },
+        )
+
+        guard.confirmPendingOptIn("opt_in_dialog_confirm")
+        val result = guard.clearPendingOptIn("note_list_unlock_request")
+
+        assertEquals(BiometricOptInReplayGuard.ClearAction.IDLE, result.action)
+        assertEquals(0L, result.promptTrigger)
+        assertFalse(result.pendingOptIn)
+        assertTrue(result.hasActiveFlow)
+        assertTrue(logMessages.any { it.contains("action=idle") })
+    }
+}


### PR DESCRIPTION
## Summary
- extract a BiometricOptInReplayGuard that owns opt-in replay state, logging, and retrigger handling
- update MainActivity AppContent to use the guard for biometric prompt triggers and opt-in confirmation
- add unit tests covering retrigger, idle, and disabled guard scenarios

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68d3309a5f988320b66443298f8ac041