### PR TITLE
Handle opt-in mismatch replay for biometric unlock

### DIFF
--- a/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/starbucknotetaker/BiometricNavigationTest.kt
@@ -182,6 +182,14 @@ class BiometricNavigationTest {
             }
         )
 
+        assertTrue(
+            "Expected opt-in mismatch fallback to retrigger unlock",
+            result.biometricLogs.any {
+                it.contains("clearPendingBiometricOptIn reason=opt_in_authenticated") &&
+                    it.contains("fallback=opt_in_mismatch")
+            }
+        )
+
         val relaunchLogIndex = result.biometricLogs.withIndex().indexOfFirst { (index, log) ->
             index > forceClearIndex &&
                 log.contains("Launching biometric prompt") &&


### PR DESCRIPTION
## Summary
- add opt-in mismatch detection in `BiometricOptInReplayGuard` so suppressed unlocks retrigger instead of stalling on stale tokens
- log the new fallback path for investigation and cover it with a regression unit test
- expand the biometric navigation instrumentation test to assert the fallback log appears when a force clear replays an unlock

## Testing
- `./gradlew test --console=plain`


------
https://chatgpt.com/codex/tasks/task_e_68d3d5434d6c83209acc62e0bc01df13