### PR TITLE
Fix biometric pending unlock navigation to run after resume

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/PendingUnlockNavigation.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PendingUnlockNavigation.kt
@@ -1,7 +1,12 @@
 package com.example.starbucknotetaker
 
 import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.whenStateAtLeast
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.lifecycle.LifecycleOwner
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 /**
  * Attempts to navigate to [noteId] after it has been unlocked. Navigation is delayed until the
@@ -26,38 +31,83 @@ suspend fun navigatePendingUnlock(
         return
     }
 
-    var navigationAttempted = false
-    try {
-        lifecycle.whenStateAtLeast(Lifecycle.State.RESUMED) {
-            val resumedPendingId = noteViewModel.pendingUnlockNavigationNoteId.value
+    fun attemptNavigation() {
+        val resumedPendingId = noteViewModel.pendingUnlockNavigationNoteId.value
+        logPendingUnlock(
+            "navigatePendingUnlock resumed noteId=${'$'}noteId pendingId=${'$'}resumedPendingId lifecycle=${'$'}{lifecycle.currentState}"
+        )
+        if (resumedPendingId != null && resumedPendingId != noteId) {
             logPendingUnlock(
-                "navigatePendingUnlock resumed noteId=${'$'}noteId pendingId=${'$'}resumedPendingId lifecycle=${'$'}{lifecycle.currentState}"
+                "navigatePendingUnlock skip_resumed_mismatch noteId=${'$'}noteId pendingId=${'$'}resumedPendingId lifecycle=${'$'}{lifecycle.currentState}"
             )
-            if (resumedPendingId != null && resumedPendingId != noteId) {
-                logPendingUnlock(
-                    "navigatePendingUnlock skip_resumed_mismatch noteId=${'$'}noteId pendingId=${'$'}resumedPendingId lifecycle=${'$'}{lifecycle.currentState}"
-                )
-                return@whenStateAtLeast
-            }
+            return
+        }
 
+        var navigationAttempted = false
+        try {
             navigationAttempted = true
             logPendingUnlock(
                 "navigatePendingUnlock navigating noteId=${'$'}noteId lifecycle=${'$'}{lifecycle.currentState}"
             )
             openNoteAfterUnlock(noteId)
+        } finally {
+            val currentPendingId = noteViewModel.pendingUnlockNavigationNoteId.value
+            if (navigationAttempted && currentPendingId == noteId) {
+                logPendingUnlock(
+                    "navigatePendingUnlock clearing noteId=${'$'}noteId pendingId=${'$'}currentPendingId lifecycle=${'$'}{lifecycle.currentState}"
+                )
+                noteViewModel.clearPendingUnlockNavigationNoteId()
+            } else {
+                logPendingUnlock(
+                    "navigatePendingUnlock skip_clearing noteId=${'$'}noteId pendingId=${'$'}currentPendingId navigationAttempted=${'$'}navigationAttempted lifecycle=${'$'}{lifecycle.currentState}"
+                )
+            }
         }
-    } finally {
-        val currentPendingId = noteViewModel.pendingUnlockNavigationNoteId.value
-        if (navigationAttempted && currentPendingId == noteId) {
-            logPendingUnlock(
-                "navigatePendingUnlock clearing noteId=${'$'}noteId pendingId=${'$'}currentPendingId lifecycle=${'$'}{lifecycle.currentState}"
-            )
-            noteViewModel.clearPendingUnlockNavigationNoteId()
-        } else {
-            logPendingUnlock(
-                "navigatePendingUnlock skip_clearing noteId=${'$'}noteId pendingId=${'$'}currentPendingId navigationAttempted=${'$'}navigationAttempted lifecycle=${'$'}{lifecycle.currentState}"
-            )
+    }
+
+    if (lifecycle.currentState.isAtLeast(Lifecycle.State.RESUMED)) {
+        attemptNavigation()
+        return
+    }
+
+    logPendingUnlock(
+        "navigatePendingUnlock waiting_for_resume noteId=${'$'}noteId pendingId=${'$'}pendingId lifecycle=${'$'}{lifecycle.currentState}"
+    )
+
+    suspendCancellableCoroutine<Unit> { continuation ->
+        val observer = object : LifecycleEventObserver {
+            override fun onStateChanged(source: LifecycleOwner, event: Lifecycle.Event) {
+                when (event) {
+                    Lifecycle.Event.ON_RESUME -> {
+                        lifecycle.removeObserver(this)
+                        try {
+                            attemptNavigation()
+                            if (continuation.isActive) {
+                                continuation.resume(Unit)
+                            }
+                        } catch (throwable: Throwable) {
+                            if (continuation.isActive) {
+                                continuation.resumeWithException(throwable)
+                            } else {
+                                throw throwable
+                            }
+                        }
+                    }
+
+                    Lifecycle.Event.ON_DESTROY -> {
+                        lifecycle.removeObserver(this)
+                        if (continuation.isActive) {
+                            continuation.cancel(CancellationException("Lifecycle destroyed before resume"))
+                        }
+                    }
+
+                    else -> Unit
+                }
+            }
         }
+
+        lifecycle.addObserver(observer)
+        continuation.invokeOnCancellation { lifecycle.removeObserver(observer) }
     }
 }
 


### PR DESCRIPTION
## Summary
- replace the biometric pending unlock helper to attach a lifecycle observer and retry navigation when the activity resumes
- ensure pending unlock state is cleared after navigation and keep existing logging, including a wait-for-resume branch
- tidy the helper imports after restructuring

## Testing
- ./gradlew test --no-configuration-cache --rerun-tasks

------
https://chatgpt.com/codex/tasks/task_e_68d56c481e4083209b6af0f68afde013