### PR TITLE
Enhance note classifier categories

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -181,7 +181,7 @@ class Summarizer(
                 emitDebug("fallback reason: $reason; classifier=${label.type}")
                 logger(reason, throwable ?: IllegalStateException(reason))
                 _state.emit(SummarizerState.Fallback)
-                return label.humanReadable
+                return trimToWordLimit(label.humanReadable, CLASSIFIER_WORD_LIMIT)
             }
 
             if (enc == null || dec == null || tok == null) {
@@ -423,7 +423,7 @@ class Summarizer(
 
     fun fallbackSummary(text: String, event: NoteEvent?): String {
         val label = runBlocking { classifyFallbackLabel(text, event) }
-        return label.humanReadable
+        return trimToWordLimit(label.humanReadable, CLASSIFIER_WORD_LIMIT)
     }
 
     private suspend fun classifyFallbackLabel(text: String, event: NoteEvent?): NoteNatureLabel {

--- a/app/src/test/java/com/example/starbucknotetaker/NoteNatureClassifierTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteNatureClassifierTest.kt
@@ -45,7 +45,7 @@ class NoteNatureClassifierTest {
         val label = classifier.classify(text, null)
 
         assertEquals(NoteNatureType.SHOPPING_LIST, label.type)
-        assertEquals(NoteNatureType.SHOPPING_LIST.humanReadable, label.humanReadable)
+        assertEquals("Shopping list with 4 items", label.humanReadable)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- enable dynamic NoteNatureLabel generation with optional builders and add new country/news categories with heuristics
- extend NoteNatureType defaults for the new categories and enrich shopping list output with item counts
- trim classifier fallback strings in the summarizer to respect word limits and update unit expectations

## Testing
- ./gradlew testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68db7db1f9f8832095092364dbdacb03