### PR TITLE
Use note excerpt as summarizer fallback

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerFallbackTest.kt
@@ -40,10 +40,13 @@ class SummarizerFallbackTest {
             debugSink = { debugMessages.add(it) }
         )
 
-        val source = "First sentence has coffee beans. Second sentence talks about roasting beans. Third sentence is ignored."
+        val source = "First sentence has coffee beans.\nSecond sentence talks about roasting beans.\nThird sentence is ignored."
         val summary = summarizer.summarize(source)
 
-        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, summary)
+        assertEquals(
+            "First sentence has coffee beans.\nSecond sentence talks about roasting beans.",
+            summary
+        )
 
         val trace = summarizer.consumeDebugTrace()
         assertTrue(

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -32,12 +32,12 @@ class SummarizerTest {
     }
 
     @Test
-    fun fallbackSummaryReturnsClassifierLabel() {
+    fun fallbackSummaryReturnsFirstTwoLines() {
         val summarizer = Summarizer(context, nativeLoader = { false }, debugSink = { })
-        val text = "Security updates require MFA for all accounts. Lunch options were discussed briefly. The security updates also add mandatory VPN use."
+        val text = "Security updates require MFA for all accounts.\nLunch options were discussed briefly.\nThe security updates also add mandatory VPN use."
         val summary = summarizer.fallbackSummary(text)
         assertEquals(
-            NoteNatureType.GENERAL_NOTE.humanReadable,
+            "Security updates require MFA for all accounts.\nLunch options were discussed briefly.",
             summary
         )
     }
@@ -66,7 +66,7 @@ class SummarizerTest {
 
         val text = "One. Two. Three."
         val result = summarizer.summarize(text)
-        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, result)
+        assertEquals("One. Two. Three.", result)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- update the summarizer fallback path to return the first two non-empty lines from the source note, only falling back to the classifier label when no text is available
- adjust unit tests to expect note excerpts when the abstractive model is unavailable

## Testing
- ./gradlew testDebugUnitTest --tests "com.example.starbucknotetaker.SummarizerTest"
- ./gradlew testDebugUnitTest --tests "com.example.starbucknotetaker.SummarizerFallbackTest"
- ./gradlew testReleaseUnitTest --tests "com.example.starbucknotetaker.SummarizerTest"
- ./gradlew testReleaseUnitTest --tests "com.example.starbucknotetaker.SummarizerFallbackTest"

------
https://chatgpt.com/codex/tasks/task_e_68db7b768bc88320b73a394dd098a902