### PR TITLE
Improve summarizer prompt with classifier context

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -497,7 +497,7 @@ class SummarizerTest {
         )
 
         val tokenizer = mock<SentencePieceProcessor>()
-        val prefix = "summarize: "
+        val prefix = "summarize the note type and structure: ${NoteNatureType.GENERAL_NOTE.humanReadable}\n\nNote: "
         val sourceTokens = intArrayOf(10, 11, 12, 13, 14)
         val summaryTokens = intArrayOf(20, 21, 22, 23)
         val abstractive = "Financial plan emphasizes launch readiness"


### PR DESCRIPTION
## Summary
- capture classifier summaries for generative runs and inject them into the prompt fed to the decoder
- ensure fallback summaries reuse the classifier wording and log when reused to keep debug traces consistent
- update the semantic paraphrase unit test to expect the richer prompt prefix

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68db83127ac8832083d4f181af101fa8