### PR TITLE
Add type-first fine-tuning flow to T5 TFLite export notebook

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -2,7 +2,8 @@
 # Fixes "untracked resource" by exporting methods on a tf.Module that owns the model.
 %pip -q install "tensorflow==2.19.0" "tf-keras==2.19.0" \
                 "transformers==4.44.2" "huggingface_hub>=0.24.0" \
-                "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0"
+                "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0" \
+                "datasets==3.1.0"
 
 import os, zipfile, gc
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
@@ -15,10 +16,12 @@ except Exception:
     pass
 
 from transformers import TFT5ForConditionalGeneration, T5Tokenizer
+from datasets import Dataset
 import numpy as np
 
 MODEL_ID = "google/flan-t5-small"
-OUT_DIR  = "flan_t5_small_tflite_min"
+FINETUNED_DIR = "flan_t5_small_type_first_finetuned"
+OUT_DIR  = "flan_t5_small_type_first_tflite_min"
 ENC_SAVED = os.path.join(OUT_DIR, "encoder_saved_model")
 DEC_SAVED = os.path.join(OUT_DIR, "decoder_step_saved_model")
 os.makedirs(OUT_DIR, exist_ok=True)
@@ -27,12 +30,81 @@ print("TF:", tf.__version__)
 
 # Load tokenizer + TF model (from PyTorch weights)
 tokenizer = T5Tokenizer.from_pretrained(MODEL_ID)
-model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID, from_pt=True)
-model.trainable = False
+base_model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID, from_pt=True)
 
 # Keep memory small
 MAX_SRC_LEN = 64
-D_MODEL = model.config.d_model
+MAX_TGT_LEN = 64
+D_MODEL = base_model.config.d_model
+
+# ---------- Load note → type-first summary dataset ----------
+examples = [
+    {
+        "note": "Latte with oat milk, 2x vanilla pumps, add whipped cream. Customer noted dairy sensitivity and requested extra napkins.",
+        "summary": "drink: latte (oat milk), modifiers: 2 vanilla, extras: whipped cream, requests: dairy sensitive, napkins=extra",
+    },
+    {
+        "note": "Order for mobile pickup: two cake pops, one triple espresso over ice, double blended. Customer wants a sticker on each cup.",
+        "summary": "drink: triple espresso (iced, double blend), food: 2 cake pops, requests: sticker per cup",
+    },
+    {
+        "note": "Daily batch note - pastry case restock counted 14 croissants, 9 blueberry muffins, 6 lemon loaves.",
+        "summary": "inventory: croissants=14, blueberry muffins=9, lemon loaves=6",
+    },
+    {
+        "note": "Training reminder: review cold brew tapping steps with new partner Ava and sign completion log.",
+        "summary": "task: training review, subject: cold brew tap, assignee: Ava, action: sign completion log",
+    },
+]
+
+raw_dataset = Dataset.from_list(examples)
+PROMPT = "summarize the note type and key counts: "
+
+def preprocess_examples(batch):
+    inputs = [PROMPT + note for note in batch["note"]]
+    tokenized = tokenizer(
+        inputs,
+        max_length=MAX_SRC_LEN,
+        truncation=True,
+        padding="max_length",
+    )
+    targets = tokenizer(
+        text_target=batch["summary"],
+        max_length=MAX_TGT_LEN,
+        truncation=True,
+        padding="max_length",
+    )
+    labels = np.array(targets["input_ids"], dtype=np.int32)
+    labels[labels == tokenizer.pad_token_id] = -100
+    tokenized["labels"] = labels
+    return tokenized
+
+tokenized_dataset = raw_dataset.map(
+    preprocess_examples,
+    batched=True,
+    remove_columns=raw_dataset.column_names,
+)
+
+BATCH_SIZE = 2
+EPOCHS = 25
+train_tf_dataset = tokenized_dataset.to_tf_dataset(
+    columns=["input_ids", "attention_mask"],
+    label_cols=["labels"],
+    shuffle=True,
+    batch_size=BATCH_SIZE,
+)
+
+optimizer = tf.keras.optimizers.Adam(learning_rate=3e-4)
+base_model.trainable = True
+base_model.compile(optimizer=optimizer)
+base_model.fit(train_tf_dataset, epochs=EPOCHS)
+
+base_model.save_pretrained(FINETUNED_DIR)
+tokenizer.save_pretrained(FINETUNED_DIR)
+
+# Reload fine-tuned weights for export
+model = TFT5ForConditionalGeneration.from_pretrained(FINETUNED_DIR)
+model.trainable = False
 
 # ---------- Export modules that TRACK the model variables ----------
 class EncoderExport(tf.Module):
@@ -103,7 +175,10 @@ convert_dynamic(ENC_SAVED, ENC_TFL); gc.collect()
 convert_dynamic(DEC_SAVED, DEC_TFL); gc.collect()
 
 # ---------- Zip + download ----------
-zip_path = "flan_t5_small_tflite_min.zip"
+ARTIFACT_NAME = "flan_t5_small_type_first_tflite_min.zip"
+# Android fetcher: publish/upload ARTIFACT_NAME to the usual /models/ path so mobile clients pull
+# flan_t5_small_type_first_tflite_min.zip instead of the previous build.
+zip_path = ARTIFACT_NAME
 with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
     for root, _, files in os.walk(OUT_DIR):
         for f in files:
@@ -112,6 +187,7 @@ with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as z:
 print("Encoder:", os.path.getsize(ENC_TFL)//1024, "KB")
 print("Decoder:", os.path.getsize(DEC_TFL)//1024, "KB")
 print("Zip:", os.path.getsize(zip_path)//1024, "KB")
+print("Android fetcher artifact:", ARTIFACT_NAME)
 
 from google.colab import files
 files.download(zip_path)
@@ -119,4 +195,4 @@ files.download(zip_path)
 # Drive fallback (uncomment if mobile download prompt misbehaves)
 # from google.colab import drive
 # drive.mount('/content/drive', force_remount=True)
-# !cp -v flan_t5_small_tflite_min.zip /content/drive/MyDrive/
+# !cp -v ${ARTIFACT_NAME} /content/drive/MyDrive/


### PR DESCRIPTION
## Summary
- install the datasets library and define a labeled note-to-type-first-summary dataset prior to export
- fine-tune FLAN-T5 on the prompt-driven summaries, save the checkpoint, and reload it for TFLite export
- rename the artifact outputs and document the new zip for Android fetchers

## Testing
- not run (notebooks only)


------
https://chatgpt.com/codex/tasks/task_e_68db83200b5c83209c14cfea00c18275