### PR TITLE
Stage TFLite artifacts into Android assets automatically

### DIFF
--- a/app/src/main/assets/README.md
+++ b/app/src/main/assets/README.md
@@ -1,12 +1,13 @@
 # Model assets
 
 This directory ships the summarisation assets that are embedded in the APK. The
-`build_tensor.ipynb` notebook fine-tunes FLAN-T5, converts it to TensorFlow Lite
-and copies the following files into this folder:
+`build_tensor.ipynb` notebook now stages the generated binaries here
+automatically after conversion, copying the following files into this folder:
 
 - `encoder_int8_dynamic.tflite`
 - `decoder_step_int8_dynamic.tflite`
 - `tokenizer.json`
 
 The app copies these assets into `context.filesDir/models` before loading them,
-and the binaries remain untracked by git for size reasons.
+and the binaries remain untracked by git for size reasons (the files are still
+listed in `.gitignore`).

--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -5,7 +5,7 @@
                 "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0" \
                 "datasets==3.1.0"
 
-import os, zipfile, gc, shutil
+import os, zipfile, gc
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
@@ -175,22 +175,33 @@ convert_dynamic(ENC_SAVED, ENC_TFL); gc.collect()
 convert_dynamic(DEC_SAVED, DEC_TFL); gc.collect()
 
 # ---------- Copy artifacts into Android assets ----------
-ASSET_DIR = os.path.join("app", "src", "main", "assets")
-os.makedirs(ASSET_DIR, exist_ok=True)
+from pathlib import Path
+import shutil
 
-tokenizer_json = os.path.join(FINETUNED_DIR, "tokenizer.json")
-if not os.path.exists(tokenizer_json):
+repo_root = Path.cwd().resolve()
+if not (repo_root / ".git").exists():
+    for parent in repo_root.parents:
+        if (parent / ".git").exists():
+            repo_root = parent
+            break
+
+ASSET_DIR = (repo_root / "app" / "src" / "main" / "assets").resolve()
+ASSET_DIR.mkdir(parents=True, exist_ok=True)
+print(f"Asset directory ready: {ASSET_DIR}")
+
+tokenizer_json = Path(FINETUNED_DIR) / "tokenizer.json"
+if not tokenizer_json.exists():
     raise FileNotFoundError(f"tokenizer.json not found at {tokenizer_json}; ensure save_pretrained emitted it")
 
 assets_to_copy = [
-    (ENC_TFL, os.path.join(ASSET_DIR, "encoder_int8_dynamic.tflite")),
-    (DEC_TFL, os.path.join(ASSET_DIR, "decoder_step_int8_dynamic.tflite")),
-    (tokenizer_json, os.path.join(ASSET_DIR, "tokenizer.json")),
+    (Path(ENC_TFL), ASSET_DIR / "encoder_int8_dynamic.tflite"),
+    (Path(DEC_TFL), ASSET_DIR / "decoder_step_int8_dynamic.tflite"),
+    (tokenizer_json, ASSET_DIR / "tokenizer.json"),
 ]
 
 for src, dst in assets_to_copy:
     shutil.copyfile(src, dst)
-    print("Copied", src, "->", dst)
+    print(f"Staged {src} -> {dst}")
 
 # ---------- Zip + download ----------
 ARTIFACT_NAME = "flan_t5_small_type_first_tflite_min.zip"
@@ -207,8 +218,17 @@ print("Decoder:", os.path.getsize(DEC_TFL)//1024, "KB")
 print("Zip:", os.path.getsize(zip_path)//1024, "KB")
 print("Android fetcher artifact:", ARTIFACT_NAME)
 
-from google.colab import files
-files.download(zip_path)
+try:
+    from google.colab import files as _colab_files
+except ModuleNotFoundError:
+    _colab_files = None
+
+if _colab_files is not None:
+    _colab_files.download(zip_path)
+    print(f"Triggered Colab download for {zip_path}")
+else:
+    print("google.colab not available; skipping browser download prompt.")
+    print(f"Artifacts staged in: {ASSET_DIR}")
 
 # Drive fallback (uncomment if mobile download prompt misbehaves)
 # from google.colab import drive


### PR DESCRIPTION
## Summary
- update the build_tensor notebook to resolve the repo root, stage the TFLite models and tokenizer into app/src/main/assets, and skip Colab-only downloads when running locally
- document that the notebook now auto-populates the Android assets directory while keeping the binaries out of git

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db9a14b8c0832083c05db5095ee403