### PR TITLE
Run build_tensor notebook and ignore generated outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ gradle/wrapper/gradle-wrapper.jar
 app/src/main/assets/*.tflite
 app/src/main/assets/*.model
 app/src/main/assets/tokenizer.json
+flan_t5_small_type_first_finetuned/
+flan_t5_small_type_first_tflite_min/
+flan_t5_small_type_first_tflite_min.zip


### PR DESCRIPTION
## Summary
- execute the build_tensor pipeline to regenerate FLAN-T5 assets for the app
- extend .gitignore so the generated fine-tuning directory, TFLite export, and zip artifact remain untracked

## Testing
- build_tensor.ipynb (executed via Python)

------
https://chatgpt.com/codex/tasks/task_e_68db9c1e54588320ad1f8cc3dae3b1ee