### PR TITLE
Ensure note editors respect keyboard insets

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -446,6 +446,7 @@ fun AddNoteScreen(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
+                .imePadding()
                 .padding(16.dp)
         ) {
             item {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -556,6 +556,7 @@ fun EditNoteScreen(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
+                .imePadding()
                 .padding(16.dp)
         ) {
             item {


### PR DESCRIPTION
## Summary
- add IME padding to the add note screen so the editor content scrolls above the keyboard
- add IME padding to the edit note screen for consistent keyboard-safe scrolling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbae6cc6fc8320af6154b48189cbe9