### PR TITLE
Ensure venue selections keep full names

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddressUtils.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddressUtils.kt
@@ -342,6 +342,24 @@ internal fun EventLocationDisplay.mergeWithFallback(fallback: EventLocationDispl
     )
 }
 
+internal fun EventLocationDisplay.toQueryString(): String {
+    val trimmedName = name.trim()
+    val trimmedAddress = address
+        ?.trim()
+        ?.takeIf { it.isNotEmpty() && !it.equals(trimmedName, ignoreCase = true) }
+
+    if (trimmedName.isNotEmpty() && trimmedAddress != null) {
+        val addressContainsName = trimmedAddress.contains(trimmedName, ignoreCase = true)
+        return if (addressContainsName) {
+            trimmedAddress
+        } else {
+            "$trimmedName, $trimmedAddress"
+        }
+    }
+
+    return trimmedName.ifEmpty { trimmedAddress.orEmpty() }
+}
+
 private fun Address.extractPoiName(): String? {
     return extractValidVenueName(this)
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EventInputs.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EventInputs.kt
@@ -155,7 +155,10 @@ fun LocationAutocompleteField(
         ) {
             suggestions.forEach { suggestion ->
                 DropdownMenuItem(onClick = {
-                    onValueChange(suggestion.text)
+                    val formattedSelection = suggestion.display
+                        .toQueryString()
+                        .ifBlank { suggestion.text }
+                    onValueChange(formattedSelection)
                     expanded = false
                     suggestions = emptyList()
                     focusRequester.requestFocus()


### PR DESCRIPTION
## Summary
- preserve venue names when inserting selected location suggestions
- add formatter to reuse resolved venue and address information when storing the query string

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dbbea5bd148320a77306bbea30bf11