### PR TITLE
Fix python script execution in Android CI workflow

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -71,23 +71,7 @@ jobs:
             "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0" \
             "datasets==3.1.0"
 
-            python <<'PY'
-            from pathlib import Path
-
-            notebook = Path("build_tensor.ipynb")
-            if not notebook.exists():
-                raise FileNotFoundError("build_tensor.ipynb not found")
-
-            filtered_lines = []
-            for line in notebook.read_text().splitlines():
-                if line.lstrip().startswith("%pip"):
-                    continue
-                filtered_lines.append(line)
-
-            code = compile("\n".join(filtered_lines), str(notebook), "exec")
-            globals_dict = {"__name__": "__main__"}
-            exec(code, globals_dict)
-            PY
+          python scripts/generate_summarizer_assets.py
 
           for file in "${REQUIRED_FILES[@]}"; do
             if [ ! -f "${ASSETS_DIR}/${file}" ]; then

--- a/scripts/generate_summarizer_assets.py
+++ b/scripts/generate_summarizer_assets.py
@@ -1,0 +1,24 @@
+"""Utility script for android-ci workflow to generate summarizer assets."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def main() -> None:
+    notebook = Path("build_tensor.ipynb")
+    if not notebook.exists():
+        raise FileNotFoundError("build_tensor.ipynb not found")
+
+    filtered_lines: list[str] = []
+    for line in notebook.read_text().splitlines():
+        if line.lstrip().startswith("%pip"):
+            continue
+        filtered_lines.append(line)
+
+    code = compile("\n".join(filtered_lines), str(notebook), "exec")
+    globals_dict = {"__name__": "__main__"}
+    exec(code, globals_dict)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a reusable script that executes the build_tensor.ipynb helper while skipping %pip lines
- call the helper script from the Android CI workflow to avoid here-doc indentation issues

## Testing
- not run (CI workflow only)


------
https://chatgpt.com/codex/tasks/task_e_68dbc1685d9483208c6a0fbfa4d3b677