### PR TITLE
Handle %pip continuations when generating summarizer assets

### DIFF
--- a/scripts/generate_summarizer_assets.py
+++ b/scripts/generate_summarizer_assets.py
@@ -10,9 +10,18 @@ def main() -> None:
         raise FileNotFoundError("build_tensor.ipynb not found")
 
     filtered_lines: list[str] = []
+    skip_continuation = False
     for line in notebook.read_text().splitlines():
-        if line.lstrip().startswith("%pip"):
+        stripped = line.lstrip()
+
+        if skip_continuation:
+            skip_continuation = stripped.endswith("\\")
             continue
+
+        if stripped.startswith("%pip"):
+            skip_continuation = stripped.endswith("\\")
+            continue
+
         filtered_lines.append(line)
 
     code = compile("\n".join(filtered_lines), str(notebook), "exec")


### PR DESCRIPTION
## Summary
- ignore %pip notebook magic lines along with their continued lines when compiling build_tensor.ipynb during CI
- prevent indentation errors caused by leftover continuation lines in the generated script

## Testing
- not run (CI issue fix)


------
https://chatgpt.com/codex/tasks/task_e_68dbc3a271848320b430f9e679b93cb8