### PR TITLE
Fix android CI missing torch dependency

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -71,6 +71,10 @@ jobs:
             "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0" \
             "datasets==3.1.0"
 
+          python -m pip install --no-cache-dir \
+            --index-url https://download.pytorch.org/whl/cpu \
+            "torch==2.5.1"
+
           python scripts/generate_summarizer_assets.py
 
           for file in "${REQUIRED_FILES[@]}"; do


### PR DESCRIPTION
## Summary
- ensure the Android CI workflow installs the CPU build of PyTorch before generating summarizer assets
- prevent the asset generation script from failing when transformers attempts to import torch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdae69b7083209767886eb8809855