### PR TITLE
Fix summarizer export under TensorFlow autograph

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -15,6 +15,8 @@ try:
 except Exception:
     pass
 
+tf.config.run_functions_eagerly(True)
+
 from transformers import TFT5ForConditionalGeneration, T5Tokenizer
 from datasets import Dataset
 import numpy as np
@@ -28,9 +30,9 @@ os.makedirs(OUT_DIR, exist_ok=True)
 
 print("TF:", tf.__version__)
 
-# Load tokenizer + TF model (from PyTorch weights)
+# Load tokenizer + TF model
 tokenizer = T5Tokenizer.from_pretrained(MODEL_ID)
-base_model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID, from_pt=True)
+base_model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID)
 
 # Keep memory small
 MAX_SRC_LEN = 64
@@ -96,7 +98,7 @@ train_tf_dataset = tokenized_dataset.to_tf_dataset(
 
 optimizer = tf.keras.optimizers.Adam(learning_rate=3e-4)
 base_model.trainable = True
-base_model.compile(optimizer=optimizer)
+base_model.compile(optimizer=optimizer, run_eagerly=True)
 base_model.fit(train_tf_dataset, epochs=EPOCHS)
 
 base_model.save_pretrained(FINETUNED_DIR)


### PR DESCRIPTION
## Summary
- run TensorFlow functions eagerly before executing the notebook in android-ci
- compile the TFT5 model with `run_eagerly=True` to avoid autograph miscompilation
- rely on the native TensorFlow checkpoint instead of forcing a PyTorch load

## Testing
- python scripts/generate_summarizer_assets.py *(manually interrupted after verifying training progressed)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdcf446e883208ed16320ca3b1247