### PR TITLE
Install summarizer Python deps in setup script

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -77,6 +77,7 @@ class Summarizer(
             _state.emit(SummarizerState.Error(t.message ?: "Failed to prepare models"))
             return
         }
+
         try {
             if (!ensureNativeTokenizerLib()) {
                 logger(
@@ -1088,6 +1089,8 @@ class Summarizer(
         private const val HEADLINE_VERB_LENGTH_LIMIT = 8
         private const val HEADLINE_SHORT_VERB_LENGTH_LIMIT = 6
         private const val SEMANTIC_SIMILARITY_THRESHOLD = 0.7f
+        private const val PLACEHOLDER_SENTINEL = "STARBUCK_NOTE_TAKER_SUMMARIZER_PLACEHOLDER"
+        private val PLACEHOLDER_SIGNATURE = PLACEHOLDER_SENTINEL.encodeToByteArray()
         private val STOP_WORDS = setOf(
             "a",
             "an",

--- a/setup_persist.sh
+++ b/setup_persist.sh
@@ -15,7 +15,7 @@ PROJECT_DIR="$(pwd)"  # assumes you're in the project root
 # Export paths
 export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$GRADLE_INSTALL_DIR/bin:$PATH"
 
-echo "📦 Starting Android SDK + Gradle setup..."
+echo "📦 Starting Android SDK + Gradle + Python dependency setup..."
 
 # ----------------------------
 # ANDROID SDK INSTALLATION
@@ -51,6 +51,28 @@ echo "📄 Writing local.properties with SDK path..."
 cat <<EOF > "$PROJECT_DIR/local.properties"
 sdk.dir=$ANDROID_SDK_ROOT
 EOF
+
+# ----------------------------
+# PYTHON DEPENDENCIES
+# ----------------------------
+PYTHON_BIN="$(command -v python3 || true)"
+if [ -z "$PYTHON_BIN" ]; then
+  echo "❌ Python 3 is required but was not found on PATH."
+  exit 1
+fi
+
+echo "🐍 Ensuring required Python packages are installed..."
+"$PYTHON_BIN" -m pip install --upgrade pip > /dev/null
+"$PYTHON_BIN" -m pip install \
+  "tensorflow==2.19.0" \
+  "tf-keras==2.19.0" \
+  "transformers==4.44.2" \
+  "huggingface_hub>=0.24.0" \
+  "numpy==2.0.2" \
+  "protobuf==5.29.1" \
+  "ml-dtypes>=0.5.0" \
+  "datasets==3.1.0" \
+  "sentencepiece>=0.2.0" > /dev/null
 
 # ----------------------------
 # GRADLE INSTALLATION


### PR DESCRIPTION
## Summary
- extend setup_persist.sh to install the TensorFlow-based summarizer dependencies alongside the Android tooling setup
- ensure the setup exits early if Python 3 is unavailable so CI clearly reports missing prerequisites

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dbea63e1648320933acface7dc64fd