### PR TITLE
Fix summarizer asset generation dependencies and exports

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -17,7 +17,7 @@ except Exception:
 
 tf.config.run_functions_eagerly(True)
 
-from transformers import TFT5ForConditionalGeneration, T5Tokenizer
+from transformers import TFT5ForConditionalGeneration, T5TokenizerFast
 from datasets import Dataset
 import numpy as np
 
@@ -31,7 +31,7 @@ os.makedirs(OUT_DIR, exist_ok=True)
 print("TF:", tf.__version__)
 
 # Load tokenizer + TF model
-tokenizer = T5Tokenizer.from_pretrained(MODEL_ID)
+tokenizer = T5TokenizerFast.from_pretrained(MODEL_ID)
 base_model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID)
 
 # Keep memory small
@@ -102,74 +102,56 @@ base_model.compile(optimizer=optimizer, run_eagerly=True)
 base_model.fit(train_tf_dataset, epochs=EPOCHS)
 
 base_model.save_pretrained(FINETUNED_DIR)
-tokenizer.save_pretrained(FINETUNED_DIR)
+tokenizer.save_pretrained(FINETUNED_DIR, legacy_format=False)
 
 # Reload fine-tuned weights for export
 model = TFT5ForConditionalGeneration.from_pretrained(FINETUNED_DIR)
 model.trainable = False
 
-# ---------- Export modules that TRACK the model variables ----------
-class EncoderExport(tf.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model  # tracked
+# ---------- Build exportable Keras models ----------
+encoder_input_ids = tf.keras.Input([MAX_SRC_LEN], dtype=tf.int32, name="input_ids")
+encoder_attention_mask = tf.keras.Input([MAX_SRC_LEN], dtype=tf.int32, name="attention_mask")
+encoder_outputs = model.encoder(
+    input_ids=encoder_input_ids,
+    attention_mask=encoder_attention_mask,
+    training=False,
+)
+encoder_model = tf.keras.Model(
+    inputs=[encoder_input_ids, encoder_attention_mask],
+    outputs={"encoder_last_hidden_state": encoder_outputs.last_hidden_state},
+    name="encoder_export",
+)
 
-    @tf.function(
-        input_signature=[
-            tf.TensorSpec([None, MAX_SRC_LEN], tf.int32, name="input_ids"),
-            tf.TensorSpec([None, MAX_SRC_LEN], tf.int32, name="attention_mask"),
-        ]
-    )
-    def __call__(self, input_ids, attention_mask):
-        enc = self.model.encoder(input_ids=input_ids,
-                                 attention_mask=attention_mask,
-                                 training=False)
-        return {"encoder_last_hidden_state": enc.last_hidden_state}
+decoder_input_ids = tf.keras.Input([1], dtype=tf.int32, name="decoder_input_ids")
+decoder_encoder_state = tf.keras.Input([MAX_SRC_LEN, D_MODEL], dtype=tf.float32, name="encoder_last_hidden_state")
+decoder_attention_mask = tf.keras.Input([MAX_SRC_LEN], dtype=tf.int32, name="encoder_attention_mask")
+decoder_outputs = model.decoder(
+    input_ids=decoder_input_ids,
+    encoder_hidden_states=decoder_encoder_state,
+    encoder_attention_mask=decoder_attention_mask,
+    use_cache=False,
+    training=False,
+)
+decoder_logits = model.lm_head(decoder_outputs.last_hidden_state)
+decoder_model = tf.keras.Model(
+    inputs=[decoder_input_ids, decoder_encoder_state, decoder_attention_mask],
+    outputs={"logits": decoder_logits},
+    name="decoder_step_export",
+)
 
-class DecoderStepExport(tf.Module):
-    def __init__(self, model):
-        super().__init__()
-        self.model = model  # tracked
-
-    @tf.function(
-        input_signature=[
-            tf.TensorSpec([None, 1], tf.int32, name="decoder_input_ids"),
-            tf.TensorSpec([None, MAX_SRC_LEN, D_MODEL], tf.float32, name="encoder_last_hidden_state"),
-            tf.TensorSpec([None, MAX_SRC_LEN], tf.int32, name="encoder_attention_mask"),
-        ]
-    )
-    def __call__(self, decoder_input_ids, encoder_last_hidden_state, encoder_attention_mask):
-        # In TF T5 (transformers 4.44.x), call model.decoder(...) directly
-        dec_out = self.model.decoder(
-            input_ids=decoder_input_ids,
-            encoder_hidden_states=encoder_last_hidden_state,
-            encoder_attention_mask=encoder_attention_mask,
-            use_cache=False,
-            training=False,
-        )
-        logits = self.model.lm_head(dec_out.last_hidden_state)  # (B,1,V)
-        return {"logits": logits}
-
-enc_export = EncoderExport(model)
-dec_export = DecoderStepExport(model)
-
-# Warm-up trace (tiny tensors)
-_dummy_inp_ids = tf.zeros([1, MAX_SRC_LEN], dtype=tf.int32)
-_dummy_attn    = tf.ones([1, MAX_SRC_LEN], dtype=tf.int32)
-enc_hidden = enc_export(_dummy_inp_ids, _dummy_attn)["encoder_last_hidden_state"]
-_ = dec_export(tf.zeros([1,1], tf.int32), enc_hidden, _dummy_attn)
-
-# ---------- Save SavedModels (the modules track the variables) ----------
-tf.saved_model.save(enc_export, ENC_SAVED)
-tf.saved_model.save(dec_export, DEC_SAVED)
+# ---------- Save SavedModels ----------
+tf.saved_model.save(encoder_model, ENC_SAVED)
+tf.saved_model.save(decoder_model, DEC_SAVED)
 
 # ---------- Convert to TFLite (INT8 dynamic only for low RAM/size) ----------
 def convert_dynamic(saved_model_dir, out_path):
+    print(f"Converting {saved_model_dir} -> {out_path}")
     conv = tf.lite.TFLiteConverter.from_saved_model(saved_model_dir)
     conv.optimizations = [tf.lite.Optimize.DEFAULT]
     tfl = conv.convert()
     with open(out_path, "wb") as f:
         f.write(tfl)
+    print(f"Wrote {out_path}")
 
 ENC_TFL = os.path.join(OUT_DIR, "encoder_int8_dynamic.tflite")
 DEC_TFL = os.path.join(OUT_DIR, "decoder_step_int8_dynamic.tflite")

--- a/scripts/generate_summarizer_assets.py
+++ b/scripts/generate_summarizer_assets.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -53,16 +54,18 @@ def _report_missing_assets(missing_paths: list[Path]) -> None:
 
 
 def _generate_with_tensorflow() -> None:
+    os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
+
     required_packages = {
         "tensorflow": "tensorflow==2.19.0",
         "tf_keras": "tf-keras==2.19.0",
+        "sentencepiece": None,
         "transformers": "transformers==4.44.2",
         "huggingface_hub": "huggingface_hub>=0.24.0",
         "numpy": "numpy==2.0.2",
-        "protobuf": "protobuf==5.29.1",
+        "google.protobuf": "protobuf==5.29.1",
         "ml_dtypes": "ml-dtypes>=0.5.0",
         "datasets": "datasets==3.1.0",
-        "sentencepiece": None,
     }
 
     for module_name, package_spec in required_packages.items():


### PR DESCRIPTION
## Summary
- ensure the TensorFlow asset generator installs protobuf via google.protobuf, forces legacy tf.keras, and installs sentencepiece before transformers
- switch the build_tensor.ipynb workflow to T5TokenizerFast, save the tokenizer in non-legacy format, and export encoder/decoder via tf.keras Models
- add progress logging around TFLite conversion to make regeneration easier to follow

## Testing
- python scripts/generate_summarizer_assets.py

------
https://chatgpt.com/codex/tasks/task_e_68dc004661fc8320a19b2f3fcbba648e