### PR TITLE
Remove summarizer state toast notifications

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -89,14 +89,8 @@ class NoteViewModel(
                     _summarizerState.value = state
                     this@NoteViewModel.context?.let { ctx ->
                         when (state) {
-                            Summarizer.SummarizerState.Ready ->
-                                NotificationInterruptionManager.runOrQueue {
-                                    Toast.makeText(ctx, "AI summarizer loaded", Toast.LENGTH_SHORT).show()
-                                }
-                            Summarizer.SummarizerState.Fallback ->
-                                NotificationInterruptionManager.runOrQueue {
-                                    Toast.makeText(ctx, "Using fallback summarization", Toast.LENGTH_SHORT).show()
-                                }
+                            Summarizer.SummarizerState.Ready -> Unit
+                            Summarizer.SummarizerState.Fallback -> Unit
                             is Summarizer.SummarizerState.Error ->
                                 NotificationInterruptionManager.runOrQueue {
                                     Toast.makeText(


### PR DESCRIPTION
## Summary
- remove the summarizer ready and fallback toast notifications from the note view model

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc4560ad50832099d3571eac5a6bad