### PR TITLE
Adjust keyboard padding in note editors

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -472,12 +472,21 @@ fun AddNoteScreen(
             )
         }
     ) { padding ->
+        val imeSpacer = (
+            WindowInsets.ime.asPaddingValues().calculateBottomPadding() -
+                WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            ).coerceAtLeast(0.dp)
         LazyColumn(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
-                .imePadding()
-                .padding(16.dp)
+                .imePadding(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                top = 16.dp,
+                bottom = 16.dp + imeSpacer,
+            )
         ) {
             item {
                 SummarizerStatusBanner(state = summarizerState)

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -582,12 +582,21 @@ fun EditNoteScreen(
             )
         }
     ) { padding ->
+        val imeSpacer = (
+            WindowInsets.ime.asPaddingValues().calculateBottomPadding() -
+                WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()
+            ).coerceAtLeast(0.dp)
         LazyColumn(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
-                .imePadding()
-                .padding(16.dp)
+                .imePadding(),
+            contentPadding = PaddingValues(
+                start = 16.dp,
+                end = 16.dp,
+                top = 16.dp,
+                bottom = 16.dp + imeSpacer,
+            )
         ) {
             item {
                 SummarizerStatusBanner(state = summarizerState)


### PR DESCRIPTION
## Summary
- derive the IME spacer from window insets in both note editor screens
- update the note editor lists to use dynamic content padding that accounts for the keyboard height

## Testing
- not run (emulator unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc4963759c83208801bcc81e197ff1