### PR TITLE
Implement rich text editing and persistence

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -405,8 +405,8 @@ fun AppContent(
         }
         composable("add") {
             AddNoteScreen(
-                onSave = { title, content, images, files, linkPreviews, event ->
-                    noteViewModel.addNote(title, content, images, files, linkPreviews, event)
+                onSave = { title, content, styledContent, images, files, linkPreviews, event ->
+                    noteViewModel.addNote(title, content, styledContent, images, files, linkPreviews, event)
                     noteViewModel.clearPendingShare()
                     navController.popBackStack()
                 },
@@ -423,9 +423,9 @@ fun AppContent(
         }
         composable("add_event") {
             AddNoteScreen(
-                onSave = { title, content, images, files, linkPreviews, event ->
+                onSave = { title, content, styledContent, images, files, linkPreviews, event ->
                     if (event != null) {
-                        noteViewModel.addNote(title, content, images, files, linkPreviews, event)
+                        noteViewModel.addNote(title, content, styledContent, images, files, linkPreviews, event)
                     }
                     navController.popBackStack()
                 },
@@ -471,8 +471,8 @@ fun AppContent(
             if (noteId != null && note != null) {
                 EditNoteScreen(
                     note = note,
-                    onSave = { title, content, images, files, linkPreviews, event ->
-                        noteViewModel.updateNote(noteId, title, content, images, files, linkPreviews, event)
+                    onSave = { title, content, styledContent, images, files, linkPreviews, event ->
+                        noteViewModel.updateNote(noteId, title, content, styledContent, images, files, linkPreviews, event)
                         navController.popBackStack()
                     },
                     onCancel = { navController.popBackStack() },

--- a/app/src/main/java/com/example/starbucknotetaker/Note.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Note.kt
@@ -3,10 +3,13 @@ package com.example.starbucknotetaker
 /**
  * Represents a note with title, textual content, creation date and optional attachments.
  */
+import com.example.starbucknotetaker.richtext.RichTextDocument
+
 data class Note(
     val id: Long = System.currentTimeMillis(),
     val title: String,
     val content: String,
+    val styledContent: RichTextDocument? = null,
     val date: Long = System.currentTimeMillis(),
     val images: List<NoteImage> = emptyList(),
     val files: List<NoteFile> = emptyList(),

--- a/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextDocument.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextDocument.kt
@@ -1,0 +1,149 @@
+package com.example.starbucknotetaker.richtext
+
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+
+/**
+ * Represents styled text content using logical spans rather than inline markup.
+ */
+data class RichTextDocument(
+    val text: String,
+    val spans: List<StyleRange> = emptyList(),
+) {
+    init {
+        require(spans.all { it.start in 0..text.length && it.end in 0..text.length && it.start <= it.end }) {
+            "Span ranges must lie within the bounds of the text."
+        }
+    }
+
+    fun toAnnotatedString(): AnnotatedString {
+        if (spans.isEmpty()) {
+            return AnnotatedString(text)
+        }
+        return buildAnnotatedString {
+            append(text)
+            spans.forEach { range ->
+                range.styles.forEach { style ->
+                    addStyle(style.toSpanStyle(), range.start, range.end)
+                }
+            }
+        }
+    }
+
+    fun toCharacterStyles(): List<Set<RichTextStyle>> {
+        if (text.isEmpty()) return emptyList()
+        val charStyles = MutableList(text.length) { mutableSetOf<RichTextStyle>() }
+        spans.forEach { range ->
+            for (index in range.start until range.end.coerceAtMost(text.length)) {
+                charStyles[index].addAll(range.styles)
+            }
+        }
+        return charStyles.map { it.toSet() }
+    }
+
+    fun isBlank(): Boolean = text.isBlank()
+
+    fun trimmed(): RichTextDocument {
+        if (text.isEmpty()) return this
+        val first = text.indexOfFirst { !it.isWhitespace() }
+        if (first == -1) return RichTextDocument("")
+        val last = text.indexOfLast { !it.isWhitespace() }
+        val newText = text.substring(first, last + 1)
+        val newSpans = spans.mapNotNull { range ->
+            val start = range.start.coerceAtLeast(first)
+            val end = range.end.coerceAtMost(last + 1)
+            if (end <= start) return@mapNotNull null
+            StyleRange(start - first, end - first, range.styles)
+        }
+        return RichTextDocument(newText, newSpans)
+    }
+
+    fun slice(start: Int, end: Int): RichTextDocument {
+        if (start >= end || start >= text.length) return RichTextDocument("")
+        val clampedStart = start.coerceAtMost(text.length)
+        val clampedEnd = end.coerceAtMost(text.length)
+        val newText = text.substring(clampedStart, clampedEnd)
+        val newSpans = spans.mapNotNull { range ->
+            val spanStart = range.start.coerceAtLeast(clampedStart)
+            val spanEnd = range.end.coerceAtMost(clampedEnd)
+            if (spanEnd <= spanStart) return@mapNotNull null
+            StyleRange(spanStart - clampedStart, spanEnd - clampedStart, range.styles)
+        }
+        return RichTextDocument(newText, newSpans)
+    }
+
+    companion object {
+        fun fromAnnotatedString(string: AnnotatedString): RichTextDocument {
+            if (string.spanStyles.isEmpty()) {
+                return RichTextDocument(string.text)
+            }
+            val ranges = string.spanStyles.map { styleRange ->
+                StyleRange(
+                    start = styleRange.start,
+                    end = styleRange.end,
+                    styles = setOfNotNull(styleRange.item.toRichTextStyle()),
+                )
+            }.filter { it.styles.isNotEmpty() }
+            return RichTextDocument(string.text, ranges)
+        }
+
+        fun fromPlainText(text: String): RichTextDocument = RichTextDocument(text)
+    }
+}
+
+private fun SpanStyle.toRichTextStyle(): RichTextStyle? = when {
+    fontWeight == FontWeight.Bold -> RichTextStyle.Bold
+    fontStyle == FontStyle.Italic -> RichTextStyle.Italic
+    textDecoration == TextDecoration.Underline -> RichTextStyle.Underline
+    else -> null
+}
+
+private fun RichTextStyle.toSpanStyle(): SpanStyle = when (this) {
+    RichTextStyle.Bold -> SpanStyle(fontWeight = FontWeight.Bold)
+    RichTextStyle.Italic -> SpanStyle(fontStyle = FontStyle.Italic)
+    RichTextStyle.Underline -> SpanStyle(textDecoration = TextDecoration.Underline)
+}
+
+/**
+ * Represents a span of rich text styles applied over a [start, end) range.
+ */
+data class StyleRange(
+    val start: Int,
+    val end: Int,
+    val styles: Set<RichTextStyle>,
+) {
+    init {
+        require(start <= end) { "Invalid range" }
+    }
+}
+
+class RichTextDocumentBuilder {
+    private val text = StringBuilder()
+    private val spans = mutableListOf<StyleRange>()
+
+    fun append(document: RichTextDocument) {
+        val offset = text.length
+        text.append(document.text)
+        document.spans.forEach { range ->
+            if (range.styles.isNotEmpty() && range.start != range.end) {
+                spans.add(
+                    StyleRange(
+                        start = offset + range.start,
+                        end = offset + range.end,
+                        styles = range.styles,
+                    ),
+                )
+            }
+        }
+    }
+
+    fun appendPlain(text: String) {
+        this.text.append(text)
+    }
+
+    fun build(): RichTextDocument = RichTextDocument(text = text.toString(), spans = spans.toList())
+}

--- a/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextStyle.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextStyle.kt
@@ -1,0 +1,7 @@
+package com.example.starbucknotetaker.richtext
+
+enum class RichTextStyle {
+    Bold,
+    Italic,
+    Underline,
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
@@ -7,43 +7,27 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
+import androidx.compose.material.IconToggleButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FormatBold
-import androidx.compose.material.icons.filled.FormatColorText
 import androidx.compose.material.icons.filled.FormatItalic
-import androidx.compose.material.icons.filled.FormatListBulleted
-import androidx.compose.material.icons.filled.FormatListNumbered
-import androidx.compose.material.icons.filled.FormatSize
 import androidx.compose.material.icons.filled.FormatUnderlined
-import androidx.compose.material.icons.filled.Highlight
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.text.TextRange
-import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-
-enum class FormattingAction {
-    Bold,
-    Italic,
-    Underline,
-    Header,
-    TextColor,
-    Highlight,
-    BulletList,
-    NumberedList,
-}
+import com.example.starbucknotetaker.richtext.RichTextStyle
 
 @Composable
 fun FormattingToolbar(
     visible: Boolean,
-    onAction: (FormattingAction) -> Unit,
+    activeStyles: Set<RichTextStyle>,
+    onToggle: (RichTextStyle) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(visible = visible, enter = fadeIn(), exit = fadeOut()) {
@@ -60,119 +44,38 @@ fun FormattingToolbar(
                     .padding(horizontal = 4.dp),
                 horizontalArrangement = Arrangement.Start,
             ) {
-                ToolbarButton(Icons.Filled.FormatBold) { onAction(FormattingAction.Bold) }
-                ToolbarButton(Icons.Filled.FormatItalic) { onAction(FormattingAction.Italic) }
-                ToolbarButton(Icons.Filled.FormatUnderlined) { onAction(FormattingAction.Underline) }
-                ToolbarButton(Icons.Filled.FormatSize) { onAction(FormattingAction.Header) }
-                ToolbarButton(Icons.Filled.FormatColorText) { onAction(FormattingAction.TextColor) }
-                ToolbarButton(Icons.Filled.Highlight) { onAction(FormattingAction.Highlight) }
-                ToolbarButton(Icons.Filled.FormatListBulleted) { onAction(FormattingAction.BulletList) }
-                ToolbarButton(Icons.Filled.FormatListNumbered) { onAction(FormattingAction.NumberedList) }
+                ToolbarToggleButton(
+                    icon = Icons.Filled.FormatBold,
+                    checked = activeStyles.contains(RichTextStyle.Bold),
+                    onCheckedChange = { onToggle(RichTextStyle.Bold) },
+                )
+                ToolbarToggleButton(
+                    icon = Icons.Filled.FormatItalic,
+                    checked = activeStyles.contains(RichTextStyle.Italic),
+                    onCheckedChange = { onToggle(RichTextStyle.Italic) },
+                )
+                ToolbarToggleButton(
+                    icon = Icons.Filled.FormatUnderlined,
+                    checked = activeStyles.contains(RichTextStyle.Underline),
+                    onCheckedChange = { onToggle(RichTextStyle.Underline) },
+                )
             }
         }
     }
 }
 
 @Composable
-private fun ToolbarButton(icon: ImageVector, onClick: () -> Unit) {
-    IconButton(onClick = onClick, modifier = Modifier.size(44.dp)) {
-        Icon(imageVector = icon, contentDescription = null, modifier = Modifier.size(20.dp))
+private fun ToolbarToggleButton(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    checked: Boolean,
+    onCheckedChange: () -> Unit,
+) {
+    IconToggleButton(
+        checked = checked,
+        onCheckedChange = { onCheckedChange() },
+        modifier = Modifier.size(44.dp),
+    ) {
+        val tint = if (checked) MaterialTheme.colors.primary else Color.Unspecified
+        Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = tint)
     }
-}
-
-fun applyTextFormatting(value: TextFieldValue, action: FormattingAction): TextFieldValue {
-    return when (action) {
-        FormattingAction.Bold -> surroundSelection(value, "**", "**", "bold text")
-        FormattingAction.Italic -> surroundSelection(value, "_", "_", "italic text")
-        FormattingAction.Underline -> surroundSelection(value, "<u>", "</u>", "underlined text")
-        FormattingAction.Header -> applyHeaderFormatting(value)
-        FormattingAction.TextColor -> surroundSelection(
-            value,
-            "<span style=\"color:red\">",
-            "</span>",
-            "colored text",
-        )
-        FormattingAction.Highlight -> surroundSelection(value, "==", "==", "highlighted text")
-        FormattingAction.BulletList -> applyListFormatting(value, prefixGenerator = { "- " })
-        FormattingAction.NumberedList -> applyListFormatting(value) { index -> "${index + 1}. " }
-    }
-}
-
-private fun surroundSelection(
-    value: TextFieldValue,
-    prefix: String,
-    suffix: String,
-    placeholder: String,
-): TextFieldValue {
-    val text = value.text
-    val selection = value.selection
-    val start = selection.min.coerceIn(0, text.length)
-    val end = selection.max.coerceIn(0, text.length)
-    val hasSelection = start != end
-    val selectedText = if (hasSelection) {
-        text.substring(start, end)
-    } else {
-        placeholder
-    }
-    val newText = buildString {
-        append(text.substring(0, start))
-        append(prefix)
-        append(selectedText)
-        append(suffix)
-        append(text.substring(end))
-    }
-    val newSelectionStart = start + prefix.length
-    val newSelectionEnd = newSelectionStart + selectedText.length
-    return value.copy(text = newText, selection = TextRange(newSelectionStart, newSelectionEnd))
-}
-
-private fun applyHeaderFormatting(value: TextFieldValue): TextFieldValue {
-    val text = value.text
-    if (text.isEmpty()) return surroundSelection(value, "# ", "", "Heading")
-    val selection = value.selection
-    val caret = selection.start.coerceIn(0, text.length)
-    val lineStart = text.lastIndexOf('\n', caret - 1).let { if (it == -1) 0 else it + 1 }
-    val lineEnd = text.indexOf('\n', caret).let { if (it == -1) text.length else it }
-    val line = text.substring(lineStart, lineEnd)
-    val trimmed = line.trimStart()
-    val indentLength = line.length - trimmed.length
-    val indent = line.take(indentLength)
-    val headerPrefix = "# "
-    val newLine = if (trimmed.startsWith(headerPrefix)) {
-        line
-    } else {
-        indent + headerPrefix + trimmed
-    }
-    val newText = text.replaceRange(lineStart, lineEnd, newLine)
-    val delta = newLine.length - line.length
-    val newStart = (selection.start + delta).coerceIn(0, newText.length)
-    val newEnd = (selection.end + delta).coerceIn(0, newText.length)
-    return value.copy(text = newText, selection = TextRange(newStart, newEnd))
-}
-
-private fun applyListFormatting(
-    value: TextFieldValue,
-    prefixGenerator: (index: Int) -> String,
-): TextFieldValue {
-    val text = value.text
-    val selection = value.selection
-    val start = selection.start.coerceIn(0, text.length)
-    val end = selection.end.coerceIn(0, text.length)
-    val lineStart = text.lastIndexOf('\n', (if (start == end) start else start) - 1).let { if (it == -1) 0 else it + 1 }
-    val lineEnd = text.indexOf('\n', end).let { if (it == -1) text.length else it }
-    val block = text.substring(lineStart, lineEnd)
-    val lines = block.split('\n')
-    val formattedLines = lines.mapIndexed { index, line ->
-        if (line.isBlank()) {
-            line
-        } else {
-            val trimmed = line.trimStart()
-            val indent = line.substring(0, line.length - trimmed.length)
-            indent + prefixGenerator(index) + trimmed
-        }
-    }
-    val replacement = formattedLines.joinToString("\n")
-    val newText = text.replaceRange(lineStart, lineEnd, replacement)
-    val newSelection = TextRange(lineStart, lineStart + replacement.length)
-    return value.copy(text = newText, selection = newSelection)
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
@@ -1,47 +1,56 @@
 package com.example.starbucknotetaker.ui
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.LocalTextStyle
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.TextFieldDefaults
-import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.TextFieldDefaults.OutlinedTextFieldDecorationBox
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
-import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material.LocalTextStyle
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsFocusedAsState
-import androidx.compose.material.TextFieldDefaults.OutlinedTextFieldDecorationBox
-import androidx.compose.foundation.layout.PaddingValues
+import com.example.starbucknotetaker.richtext.RichTextStyle
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun RichTextEditor(
-    value: TextFieldValue,
-    onValueChange: (TextFieldValue) -> Unit,
+    value: RichTextValue,
+    onValueChange: (RichTextValue) -> Unit,
     modifier: Modifier = Modifier,
     label: (@Composable () -> Unit)? = null,
-    onAction: (FormattingAction) -> Unit,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val colors = TextFieldDefaults.outlinedTextFieldColors()
+    val state = remember { RichTextState(value) }
+
+    LaunchedEffect(value) {
+        if (value != state.value) {
+            state.setExternalValue(value)
+        }
+    }
 
     BasicTextField(
-        value = value,
-        onValueChange = onValueChange,
-        modifier = modifier
-            .fillMaxWidth(),
+        value = state.asTextFieldValue(),
+        onValueChange = { newValue ->
+            state.updateFromTextField(newValue)
+            onValueChange(state.value)
+        },
+        modifier = modifier.fillMaxWidth(),
         textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colors.onSurface),
         cursorBrush = SolidColor(MaterialTheme.colors.primary),
         keyboardOptions = keyboardOptions,
@@ -49,13 +58,19 @@ fun RichTextEditor(
         interactionSource = interactionSource,
         decorationBox = { innerTextField ->
             OutlinedTextFieldDecorationBox(
-                value = value.text,
+                value = state.value.text,
                 visualTransformation = VisualTransformation.None,
                 innerTextField = {
                     Column(modifier = Modifier.fillMaxWidth()) {
                         FormattingToolbar(
                             visible = isFocused,
-                            onAction = onAction,
+                            activeStyles = state.activeStyles,
+                            onToggle = { style: RichTextStyle ->
+                                state.toggleStyle(style)
+                                if (state.value != value) {
+                                    onValueChange(state.value)
+                                }
+                            },
                             modifier = Modifier.fillMaxWidth(),
                         )
                         innerTextField()

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextState.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextState.kt
@@ -1,0 +1,90 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.TextRange
+import androidx.compose.ui.text.input.TextFieldValue
+import com.example.starbucknotetaker.richtext.RichTextStyle
+
+class RichTextState(initialValue: RichTextValue) {
+    var value by mutableStateOf(initialValue)
+        private set
+
+    var activeStyles by mutableStateOf(value.stylesAt(value.selection))
+        private set
+
+    fun setExternalValue(newValue: RichTextValue) {
+        value = newValue
+        activeStyles = value.stylesAt(value.selection)
+    }
+
+    fun asTextFieldValue(): TextFieldValue {
+        val annotated = value.toDocument().toAnnotatedString()
+        return TextFieldValue(annotated, value.selection)
+    }
+
+    fun updateFromTextField(newValue: TextFieldValue) {
+        val oldText = value.text
+        val newText = newValue.text
+        val oldSelection = value.selection
+        val prefixLength = oldText.commonPrefixWith(newText).length
+        val oldSuffixPortion = oldText.substring(prefixLength)
+        val newSuffixPortion = newText.substring(prefixLength)
+        val suffixLength = oldSuffixPortion.commonSuffixWith(newSuffixPortion).length
+        val removedLength = oldText.length - prefixLength - suffixLength
+        val insertedLength = newText.length - prefixLength - suffixLength
+        val newStyles = value.characterStyles.toMutableList()
+        repeat(removedLength) {
+            if (prefixLength < newStyles.size) {
+                newStyles.removeAt(prefixLength)
+            }
+        }
+        if (insertedLength > 0) {
+            val insertStyles = List(insertedLength) { activeStyles.toSet() }
+            newStyles.addAll(prefixLength, insertStyles)
+        }
+        while (newStyles.size < newText.length) {
+            newStyles.add(emptySet())
+        }
+        val adjustedStyles = newStyles.take(newText.length)
+        val adjustedSelection = TextRange(
+            newValue.selection.start.coerceIn(0, newText.length),
+            newValue.selection.end.coerceIn(0, newText.length),
+        )
+        value = RichTextValue(newText, adjustedSelection, adjustedStyles)
+        val selectionChanged = oldSelection != adjustedSelection
+        if (selectionChanged) {
+            activeStyles = value.stylesAt(adjustedSelection)
+        }
+    }
+
+    fun toggleStyle(style: RichTextStyle) {
+        val selection = value.selection
+        if (selection.start == selection.end) {
+            activeStyles = if (activeStyles.contains(style)) {
+                activeStyles - style
+            } else {
+                activeStyles + style
+            }
+            return
+        }
+        val start = selection.start.coerceAtMost(selection.end).coerceIn(0, value.text.length)
+        val end = selection.end.coerceAtLeast(selection.start).coerceIn(0, value.text.length)
+        val shouldAdd = !value.rangeHasStyle(style, start, end)
+        val updated = value.characterStyles.toMutableList()
+        for (index in start until end) {
+            val set = updated.getOrNull(index)?.toMutableSet() ?: mutableSetOf()
+            if (shouldAdd) {
+                set.add(style)
+            } else {
+                set.remove(style)
+            }
+            if (index < updated.size) {
+                updated[index] = set
+            }
+        }
+        value = value.copy(characterStyles = updated)
+        activeStyles = value.stylesAt(selection)
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextValue.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextValue.kt
@@ -1,0 +1,99 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.ui.text.TextRange
+import com.example.starbucknotetaker.richtext.RichTextDocument
+import com.example.starbucknotetaker.richtext.RichTextStyle
+import com.example.starbucknotetaker.richtext.RichTextDocumentBuilder
+
+/**
+ * Represents the editable state of a rich text field.
+ */
+data class RichTextValue(
+    val text: String,
+    val selection: TextRange,
+    val characterStyles: List<Set<RichTextStyle>>,
+) {
+    init {
+        require(characterStyles.size == text.length) {
+            "characterStyles must contain one entry per character"
+        }
+    }
+
+    fun toDocument(): RichTextDocument {
+        if (text.isEmpty()) {
+            return RichTextDocument(text = "")
+        }
+        val builder = RichTextDocumentBuilder()
+        var index = 0
+        while (index < text.length) {
+            val styles = characterStyles.getOrElse(index) { emptySet() }
+            val runEnd = findRunEnd(index, styles)
+            if (styles.isEmpty()) {
+                builder.appendPlain(text.substring(index, runEnd))
+            } else {
+                val fragment = RichTextDocument(
+                    text = text.substring(index, runEnd),
+                    spans = if (styles.isEmpty()) emptyList() else listOf(
+                        com.example.starbucknotetaker.richtext.StyleRange(0, runEnd - index, styles),
+                    ),
+                )
+                builder.append(fragment)
+            }
+            index = runEnd
+        }
+        return builder.build()
+    }
+
+    private fun findRunEnd(start: Int, styles: Set<RichTextStyle>): Int {
+        var index = start
+        while (index < text.length && characterStyles.getOrElse(index) { emptySet() } == styles) {
+            index++
+        }
+        return index
+    }
+
+    fun stylesAt(range: TextRange): Set<RichTextStyle> {
+        if (text.isEmpty()) return emptySet()
+        val start = range.start.coerceIn(0, text.length)
+        val end = range.end.coerceIn(0, text.length)
+        if (start == end) {
+            val caret = start.coerceAtLeast(1)
+            return characterStyles.getOrNull(caret - 1)?.toSet() ?: emptySet()
+        }
+        var index = start
+        var styles: Set<RichTextStyle>? = null
+        while (index < end) {
+            val current = characterStyles.getOrNull(index)?.toSet().orEmpty()
+            styles = styles?.intersect(current) ?: current
+            if (styles.isNullOrEmpty()) return emptySet()
+            index++
+        }
+        return styles ?: emptySet()
+    }
+
+    fun rangeHasStyle(style: RichTextStyle, start: Int, end: Int): Boolean {
+        if (start >= end) return false
+        for (index in start until end) {
+            if (!characterStyles.getOrNull(index).orEmpty().contains(style)) return false
+        }
+        return true
+    }
+
+    companion object {
+        fun empty(): RichTextValue = RichTextValue("", TextRange.Zero, emptyList())
+
+        fun fromDocument(document: RichTextDocument): RichTextValue {
+            val styles = document.toCharacterStyles()
+            return RichTextValue(
+                text = document.text,
+                selection = TextRange(document.text.length),
+                characterStyles = styles,
+            )
+        }
+
+        fun fromPlainText(text: String): RichTextValue {
+            val chars = List(text.length) { emptySet<RichTextStyle>() }
+            return RichTextValue(text, TextRange(text.length), chars)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the markup-based editor with a dedicated rich text state and formatting toolbar toggles
- persist styled note content in the data model and encrypted storage alongside existing placeholders
- update note creation, editing, and detail views to render the stored rich text spans

## Testing
- ./gradlew lint --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dc5927e08083208dca1a920c76ff25