### PR TITLE
Remove header formatting option from toolbar

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
@@ -10,24 +10,34 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.IconToggleButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FormatBold
 import androidx.compose.material.icons.filled.FormatItalic
+import androidx.compose.material.icons.filled.FormatListBulleted
+import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.FormatUnderlined
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.richtext.RichTextStyle
+
+enum class FormattingAction {
+    BulletList,
+    NumberedList,
+}
 
 @Composable
 fun FormattingToolbar(
     visible: Boolean,
     activeStyles: Set<RichTextStyle>,
     onToggle: (RichTextStyle) -> Unit,
+    onAction: (FormattingAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     AnimatedVisibility(visible = visible, enter = fadeIn(), exit = fadeOut()) {
@@ -59,6 +69,12 @@ fun FormattingToolbar(
                     checked = activeStyles.contains(RichTextStyle.Underline),
                     onCheckedChange = { onToggle(RichTextStyle.Underline) },
                 )
+                ToolbarActionButton(Icons.Filled.FormatListBulleted) {
+                    onAction(FormattingAction.BulletList)
+                }
+                ToolbarActionButton(Icons.Filled.FormatListNumbered) {
+                    onAction(FormattingAction.NumberedList)
+                }
             }
         }
     }
@@ -66,7 +82,7 @@ fun FormattingToolbar(
 
 @Composable
 private fun ToolbarToggleButton(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    icon: ImageVector,
     checked: Boolean,
     onCheckedChange: () -> Unit,
 ) {
@@ -77,5 +93,22 @@ private fun ToolbarToggleButton(
     ) {
         val tint = if (checked) MaterialTheme.colors.primary else Color.Unspecified
         Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = tint)
+    }
+}
+
+@Composable
+private fun ToolbarActionButton(
+    icon: ImageVector,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.size(44.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+        )
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
@@ -71,6 +71,10 @@ fun RichTextEditor(
                                     onValueChange(state.value)
                                 }
                             },
+                            onAction = { action ->
+                                state.applyFormattingAction(action)
+                                onValueChange(state.value)
+                            },
                             modifier = Modifier.fillMaxWidth(),
                         )
                         innerTextField()

--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -1,6 +1,7 @@
 package com.example.starbucknotetaker
 
 import androidx.lifecycle.SavedStateHandle
+import com.example.starbucknotetaker.richtext.RichTextDocument
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -41,7 +42,14 @@ class NoteViewModelTest {
         val viewModel = NoteViewModel(SavedStateHandle())
         setField(viewModel, "summarizer", summarizer)
 
-        viewModel.addNote("Title", "Content", emptyList(), emptyList(), emptyList())
+        viewModel.addNote(
+            "Title",
+            "Content",
+            RichTextDocument.fromPlainText("Content"),
+            emptyList(),
+            emptyList(),
+            emptyList(),
+        )
 
         assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, viewModel.notes[0].summary)
 


### PR DESCRIPTION
## Summary
- remove the header formatting enum entry and FormatSize icon from the formatting toolbar while keeping bold/italic/underline toggles alongside bullet and numbered list actions
- hook the toolbar actions into the rich text editor state to format selected lines and update active styles without disturbing existing character styling
- update the view model unit test to construct a RichTextDocument when adding a note so it matches the new editor data model

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68dc634f3ce88320ae1e663e37bf49a2