### PR TITLE
Improve Enter handling for lists in rich text editor

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
@@ -19,6 +19,11 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import com.example.starbucknotetaker.richtext.RichTextStyle
@@ -50,7 +55,21 @@ fun RichTextEditor(
             state.updateFromTextField(newValue)
             onValueChange(state.value)
         },
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .onPreviewKeyEvent { event ->
+                if (event.type == KeyEventType.KeyDown &&
+                    (event.key == Key.Enter || event.key == Key.NumPadEnter)
+                ) {
+                    val handled = state.handleEnterKey()
+                    if (handled) {
+                        onValueChange(state.value)
+                    }
+                    handled
+                } else {
+                    false
+                }
+            },
         textStyle = LocalTextStyle.current.copy(color = MaterialTheme.colors.onSurface),
         cursorBrush = SolidColor(MaterialTheme.colors.primary),
         keyboardOptions = keyboardOptions,

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextState.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextState.kt
@@ -90,83 +90,19 @@ class RichTextState(initialValue: RichTextValue) {
 
     fun applyFormattingAction(action: FormattingAction) {
         val newValue = when (action) {
-            FormattingAction.BulletList -> value.applyListFormatting { "- " }
-            FormattingAction.NumberedList -> value.applyListFormatting { index -> "${index + 1}. " }
+            FormattingAction.BulletList -> value.applyListFormatting("• ", ListItemType.Bullet)
+            FormattingAction.NumberedList -> value.applyListFormatting("1. ", ListItemType.Numbered)
         }
         if (newValue != value) {
             value = newValue
         }
         activeStyles = value.stylesAt(value.selection)
     }
-}
 
-private fun RichTextValue.applyListFormatting(
-    prefixGenerator: (index: Int) -> String,
-): RichTextValue {
-    if (text.isEmpty()) return this
-    val start = selection.start.coerceAtMost(selection.end).coerceIn(0, text.length)
-    val end = selection.end.coerceAtLeast(selection.start).coerceIn(0, text.length)
-    val lineStart = text.lastIndexOf('\n', start - 1).let { if (it == -1) 0 else it + 1 }
-    val lineEnd = text.indexOf('\n', end).let { if (it == -1) text.length else it }
-    if (lineStart >= lineEnd) return this
-
-    val replacementBuilder = StringBuilder()
-    val replacementStyles = mutableListOf<Set<RichTextStyle>>()
-    var lineIndex = 0
-    var current = lineStart
-    while (current < lineEnd) {
-        val nextBreakRaw = text.indexOf('\n', current)
-        val nextBreak = when {
-            nextBreakRaw == -1 -> lineEnd
-            nextBreakRaw > lineEnd -> lineEnd
-            else -> nextBreakRaw
-        }
-        val lineText = text.substring(current, nextBreak)
-        val firstNonWhitespace = lineText.indexOfFirst { !it.isWhitespace() }
-        val indentLength = if (firstNonWhitespace == -1) lineText.length else firstNonWhitespace
-        val trimmedStart = current + indentLength
-        val prefix = if (indentLength == lineText.length) {
-            ""
-        } else {
-            prefixGenerator(lineIndex)
-        }
-
-        if (indentLength > 0) {
-            for (i in current until trimmedStart.coerceAtMost(nextBreak)) {
-                replacementBuilder.append(text[i])
-                replacementStyles.add(characterStyles.getOrNull(i) ?: emptySet())
-            }
-        }
-
-        if (prefix.isNotEmpty()) {
-            replacementBuilder.append(prefix)
-            repeat(prefix.length) { replacementStyles.add(emptySet()) }
-        }
-
-        for (i in trimmedStart until nextBreak) {
-            replacementBuilder.append(text[i])
-            replacementStyles.add(characterStyles.getOrNull(i) ?: emptySet())
-        }
-
-        if (nextBreak < lineEnd) {
-            replacementBuilder.append('\n')
-            replacementStyles.add(characterStyles.getOrNull(nextBreak) ?: emptySet())
-        }
-
-        current = if (nextBreak < lineEnd) nextBreak + 1 else lineEnd
-        lineIndex++
+    fun handleEnterKey(): Boolean {
+        val newValue = value.handleListEnter() ?: return false
+        value = newValue
+        activeStyles = value.stylesAt(value.selection)
+        return true
     }
-
-    val replacement = replacementBuilder.toString()
-    val newText = text.replaceRange(lineStart, lineEnd, replacement)
-    val newStyles = characterStyles.toMutableList()
-    val removeCount = lineEnd - lineStart
-    repeat(removeCount) {
-        if (lineStart < newStyles.size) {
-            newStyles.removeAt(lineStart)
-        }
-    }
-    newStyles.addAll(lineStart, replacementStyles)
-    val newSelection = TextRange(lineStart, lineStart + replacement.length)
-    return copy(text = newText, selection = newSelection, characterStyles = newStyles)
 }

--- a/app/src/test/java/com/example/starbucknotetaker/ui/RichTextListBehaviorTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/ui/RichTextListBehaviorTest.kt
@@ -1,0 +1,90 @@
+package com.example.starbucknotetaker.ui
+
+import androidx.compose.ui.text.TextRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class RichTextListBehaviorTest {
+
+    @Test
+    fun bulletEnterInsertsNewItemPrefix() {
+        val initialText = "• First"
+        val state = RichTextState(plainValue(initialText, initialText.length))
+
+        val handled = state.handleEnterKey()
+
+        assertTrue(handled)
+        assertEquals("• First\n• ", state.value.text)
+        assertEquals(state.value.text.length, state.value.selection.start)
+        assertEquals(state.value.selection.start, state.value.selection.end)
+        assertEquals(state.value.text.length, state.value.characterStyles.size)
+    }
+
+    @Test
+    fun bulletEnterOnEmptyItemExitsList() {
+        val state = RichTextState(plainValue("• ", 2))
+
+        val handled = state.handleEnterKey()
+
+        assertTrue(handled)
+        assertEquals("\n", state.value.text)
+        assertEquals(1, state.value.selection.start)
+        assertEquals(state.value.selection.start, state.value.selection.end)
+        assertEquals(state.value.text.length, state.value.characterStyles.size)
+    }
+
+    @Test
+    fun numberedEnterAddsIncrementedItem() {
+        val initialText = "1. Item"
+        val state = RichTextState(plainValue(initialText, initialText.length))
+
+        val handled = state.handleEnterKey()
+
+        assertTrue(handled)
+        assertEquals("1. Item\n2. ", state.value.text)
+        assertEquals(state.value.text.length, state.value.selection.start)
+        assertEquals(state.value.selection.start, state.value.selection.end)
+    }
+
+    @Test
+    fun bulletEnterSplitsParagraph() {
+        val initialText = "• Hello world"
+        val caret = "• Hello ".length
+        val state = RichTextState(plainValue(initialText, caret))
+
+        val handled = state.handleEnterKey()
+
+        assertTrue(handled)
+        assertEquals("• Hello \n• world", state.value.text)
+    }
+
+    @Test
+    fun applyBulletFormattingInsertsPrefixAndMovesCaret() {
+        val state = RichTextState(RichTextValue.empty())
+
+        state.applyFormattingAction(FormattingAction.BulletList)
+
+        assertEquals("• ", state.value.text)
+        assertEquals(TextRange(2), state.value.selection)
+    }
+
+    @Test
+    fun applyNumberedFormattingStartsAtOne() {
+        val baseText = "Example"
+        val state = RichTextState(plainValue(baseText, baseText.length))
+
+        state.applyFormattingAction(FormattingAction.NumberedList)
+
+        assertEquals("1. Example", state.value.text)
+        assertEquals(TextRange(baseText.length + 3), state.value.selection)
+    }
+
+    private fun plainValue(text: String, selection: Int): RichTextValue {
+        return RichTextValue(
+            text = text,
+            selection = TextRange(selection),
+            characterStyles = List(text.length) { emptySet() },
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- intercept Enter in the rich text editor to continue lists, add the next prefix, or exit when the item is empty
- refactor list formatting logic to use bullet characters, start numbering at one, and keep the caret after the inserted prefix
- add unit coverage for bullet and numbered list behaviors, including Enter handling and toolbar actions

## Testing
- ./gradlew testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68dc66bdb9188320a359869cb2032670