### PR TITLE
Add highlight and text color formatting and refine fallback UI

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -486,6 +486,9 @@ class Summarizer(
         for (line in text.lineSequence()) {
             if (lines.size >= FALLBACK_LINE_LIMIT) break
             val trimmed = line.trim()
+            if (trimmed.startsWith("Title:", ignoreCase = true)) {
+                continue
+            }
             if (trimmed.isNotEmpty()) {
                 lines.add(trimmed)
             }

--- a/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextStyle.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/richtext/RichTextStyle.kt
@@ -1,7 +1,11 @@
 package com.example.starbucknotetaker.richtext
 
-enum class RichTextStyle {
-    Bold,
-    Italic,
-    Underline,
+import androidx.compose.ui.graphics.Color
+
+sealed class RichTextStyle {
+    object Bold : RichTextStyle()
+    object Italic : RichTextStyle()
+    object Underline : RichTextStyle()
+    data class Highlight(val color: Color) : RichTextStyle()
+    data class TextColor(val color: Color) : RichTextStyle()
 }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/FormattingToolbar.kt
@@ -3,25 +3,44 @@ package com.example.starbucknotetaker.ui
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.IconToggleButton
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.FormatBold
+import androidx.compose.material.icons.filled.FormatColorReset
+import androidx.compose.material.icons.filled.FormatColorText
 import androidx.compose.material.icons.filled.FormatItalic
 import androidx.compose.material.icons.filled.FormatListBulleted
 import androidx.compose.material.icons.filled.FormatListNumbered
 import androidx.compose.material.icons.filled.FormatUnderlined
+import androidx.compose.material.icons.filled.Highlight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
@@ -36,10 +55,16 @@ enum class FormattingAction {
 fun FormattingToolbar(
     visible: Boolean,
     activeStyles: Set<RichTextStyle>,
-    onToggle: (RichTextStyle) -> Unit,
+    onToggleStyle: (RichTextStyle) -> Unit,
+    onToggleHighlight: (Color) -> Unit,
+    onSelectTextColor: (Color?) -> Unit,
     onAction: (FormattingAction) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var showColorDialog by remember { mutableStateOf(false) }
+    val highlightStyle = activeStyles.firstOrNull { it is RichTextStyle.Highlight } as? RichTextStyle.Highlight
+    val textColorStyle = activeStyles.firstOrNull { it is RichTextStyle.TextColor } as? RichTextStyle.TextColor
+
     AnimatedVisibility(visible = visible, enter = fadeIn(), exit = fadeOut()) {
         Surface(
             modifier = modifier
@@ -57,17 +82,31 @@ fun FormattingToolbar(
                 ToolbarToggleButton(
                     icon = Icons.Filled.FormatBold,
                     checked = activeStyles.contains(RichTextStyle.Bold),
-                    onCheckedChange = { onToggle(RichTextStyle.Bold) },
+                    onCheckedChange = { onToggleStyle(RichTextStyle.Bold) },
                 )
                 ToolbarToggleButton(
                     icon = Icons.Filled.FormatItalic,
                     checked = activeStyles.contains(RichTextStyle.Italic),
-                    onCheckedChange = { onToggle(RichTextStyle.Italic) },
+                    onCheckedChange = { onToggleStyle(RichTextStyle.Italic) },
                 )
                 ToolbarToggleButton(
                     icon = Icons.Filled.FormatUnderlined,
                     checked = activeStyles.contains(RichTextStyle.Underline),
-                    onCheckedChange = { onToggle(RichTextStyle.Underline) },
+                    onCheckedChange = { onToggleStyle(RichTextStyle.Underline) },
+                )
+                ToolbarToggleButton(
+                    icon = Icons.Filled.Highlight,
+                    checked = highlightStyle != null,
+                    onCheckedChange = {
+                        val color = highlightStyle?.color ?: DefaultHighlightColor
+                        onToggleHighlight(color)
+                    },
+                    checkedTint = highlightStyle?.color ?: DefaultHighlightColor,
+                )
+                ToolbarColorButton(
+                    icon = Icons.Filled.FormatColorText,
+                    selectedColor = textColorStyle?.color,
+                    onClick = { showColorDialog = true },
                 )
                 ToolbarActionButton(Icons.Filled.FormatListBulleted) {
                     onAction(FormattingAction.BulletList)
@@ -78,6 +117,17 @@ fun FormattingToolbar(
             }
         }
     }
+
+    if (showColorDialog) {
+        ColorSelectionDialog(
+            selectedColor = textColorStyle?.color,
+            onDismiss = { showColorDialog = false },
+            onColorSelected = { color ->
+                showColorDialog = false
+                onSelectTextColor(color)
+            },
+        )
+    }
 }
 
 @Composable
@@ -85,14 +135,38 @@ private fun ToolbarToggleButton(
     icon: ImageVector,
     checked: Boolean,
     onCheckedChange: () -> Unit,
+    checkedTint: Color? = null,
 ) {
     IconToggleButton(
         checked = checked,
         onCheckedChange = { onCheckedChange() },
         modifier = Modifier.size(44.dp),
     ) {
-        val tint = if (checked) MaterialTheme.colors.primary else Color.Unspecified
+        val tint = when {
+            checked && checkedTint != null -> checkedTint
+            checked -> MaterialTheme.colors.primary
+            else -> Color.Unspecified
+        }
         Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = tint)
+    }
+}
+
+@Composable
+private fun ToolbarColorButton(
+    icon: ImageVector,
+    selectedColor: Color?,
+    onClick: () -> Unit,
+) {
+    IconButton(
+        onClick = onClick,
+        modifier = Modifier.size(44.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            modifier = Modifier.size(20.dp),
+            tint = selectedColor ?: MaterialTheme.colors.onSurface,
+        )
     }
 }
 
@@ -112,3 +186,98 @@ private fun ToolbarActionButton(
         )
     }
 }
+
+@Composable
+private fun ColorSelectionDialog(
+    selectedColor: Color?,
+    onDismiss: () -> Unit,
+    onColorSelected: (Color?) -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Text colour") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+                val options = listOf<Color?>(null) + TextColorOptions
+                options.chunked(COLOR_GRID_COLUMNS).forEach { row ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    ) {
+                        row.forEach { color ->
+                            ColorSwatch(
+                                color = color,
+                                isSelected = if (color == null) {
+                                    selectedColor == null
+                                } else {
+                                    selectedColor == color
+                                },
+                                onSelect = { onColorSelected(color) },
+                            )
+                        }
+                        if (row.size < COLOR_GRID_COLUMNS) {
+                            repeat(COLOR_GRID_COLUMNS - row.size) {
+                                Spacer(modifier = Modifier.size(40.dp))
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+@Composable
+private fun ColorSwatch(
+    color: Color?,
+    isSelected: Boolean,
+    onSelect: () -> Unit,
+) {
+    val borderColor = if (isSelected) {
+        MaterialTheme.colors.primary
+    } else {
+        MaterialTheme.colors.onSurface.copy(alpha = 0.2f)
+    }
+    Box(
+        modifier = Modifier
+            .size(40.dp)
+            .clip(CircleShape)
+            .background(color ?: MaterialTheme.colors.surface)
+            .border(width = if (isSelected) 2.dp else 1.dp, color = borderColor, shape = CircleShape)
+            .clickable(onClick = onSelect),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (color == null) {
+            Icon(
+                imageVector = Icons.Filled.FormatColorReset,
+                contentDescription = null,
+                tint = MaterialTheme.colors.onSurface,
+            )
+        }
+    }
+}
+
+private val DefaultHighlightColor = Color(0xFFFFFF8D)
+
+private val TextColorOptions = listOf(
+    Color(0xFF000000),
+    Color(0xFF37474F),
+    Color(0xFFEF5350),
+    Color(0xFFFF7043),
+    Color(0xFFFFCA28),
+    Color(0xFF66BB6A),
+    Color(0xFF26A69A),
+    Color(0xFF42A5F5),
+    Color(0xFF5C6BC0),
+    Color(0xFF7E57C2),
+    Color(0xFFEC407A),
+    Color(0xFF8D6E63),
+)
+
+private const val COLOR_GRID_COLUMNS = 4

--- a/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/RichTextEditor.kt
@@ -84,8 +84,24 @@ fun RichTextEditor(
                         FormattingToolbar(
                             visible = isFocused,
                             activeStyles = state.activeStyles,
-                            onToggle = { style: RichTextStyle ->
-                                state.toggleStyle(style)
+                            onToggleStyle = { style: RichTextStyle ->
+                                state.toggleInlineStyle(style)
+                                if (state.value != value) {
+                                    onValueChange(state.value)
+                                }
+                            },
+                            onToggleHighlight = { color ->
+                                state.toggleHighlight(color)
+                                if (state.value != value) {
+                                    onValueChange(state.value)
+                                }
+                            },
+                            onSelectTextColor = { color ->
+                                if (color == null) {
+                                    state.clearTextColor()
+                                } else {
+                                    state.applyTextColor(color)
+                                }
                                 if (state.value != value) {
                                     onValueChange(state.value)
                                 }
@@ -111,7 +127,7 @@ fun RichTextEditor(
                 contentPadding = PaddingValues(
                     start = 16.dp,
                     end = 16.dp,
-                    top = if (isFocused) 52.dp else 24.dp,
+                    top = if (isFocused) 0.dp else 16.dp,
                     bottom = 16.dp,
                 ),
             )

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SummarizerStatusBanner.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SummarizerStatusBanner.kt
@@ -13,7 +13,6 @@ import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ErrorOutline
-import androidx.compose.material.icons.filled.Info
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -42,20 +41,7 @@ fun SummarizerStatusBanner(
                 Text("Loading AI summarizer…")
             }
         }
-        Summarizer.SummarizerState.Fallback -> {
-            BannerContainer(
-                background = MaterialTheme.colors.primary.copy(alpha = 0.08f),
-                modifier = modifier
-            ) {
-                Icon(
-                    imageVector = Icons.Default.Info,
-                    contentDescription = null,
-                    tint = MaterialTheme.colors.primary
-                )
-                Spacer(Modifier.size(12.dp))
-                Text("Using fallback summarization")
-            }
-        }
+        Summarizer.SummarizerState.Fallback -> Unit
         is Summarizer.SummarizerState.Error -> {
             BannerContainer(
                 background = MaterialTheme.colors.error.copy(alpha = 0.1f),

--- a/app/src/test/java/com/example/starbucknotetaker/ui/RichTextListBehaviorTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/ui/RichTextListBehaviorTest.kt
@@ -7,15 +7,17 @@ import org.junit.Test
 
 class RichTextListBehaviorTest {
 
+    private val indent = "    "
+
     @Test
     fun bulletEnterInsertsNewItemPrefix() {
-        val initialText = "• First"
+        val initialText = "${indent}• First"
         val state = RichTextState(plainValue(initialText, initialText.length))
 
         val handled = state.handleEnterKey()
 
         assertTrue(handled)
-        assertEquals("• First\n• ", state.value.text)
+        assertEquals("${indent}• First\n${indent}• ", state.value.text)
         assertEquals(state.value.text.length, state.value.selection.start)
         assertEquals(state.value.selection.start, state.value.selection.end)
         assertEquals(state.value.text.length, state.value.characterStyles.size)
@@ -23,7 +25,7 @@ class RichTextListBehaviorTest {
 
     @Test
     fun bulletEnterOnEmptyItemExitsList() {
-        val state = RichTextState(plainValue("• ", 2))
+        val state = RichTextState(plainValue("${indent}• ", indent.length + 2))
 
         val handled = state.handleEnterKey()
 
@@ -36,27 +38,27 @@ class RichTextListBehaviorTest {
 
     @Test
     fun numberedEnterAddsIncrementedItem() {
-        val initialText = "1. Item"
+        val initialText = "${indent}1. Item"
         val state = RichTextState(plainValue(initialText, initialText.length))
 
         val handled = state.handleEnterKey()
 
         assertTrue(handled)
-        assertEquals("1. Item\n2. ", state.value.text)
+        assertEquals("${indent}1. Item\n${indent}2. ", state.value.text)
         assertEquals(state.value.text.length, state.value.selection.start)
         assertEquals(state.value.selection.start, state.value.selection.end)
     }
 
     @Test
     fun bulletEnterSplitsParagraph() {
-        val initialText = "• Hello world"
-        val caret = "• Hello ".length
+        val initialText = "${indent}• Hello world"
+        val caret = "${indent}• Hello ".length
         val state = RichTextState(plainValue(initialText, caret))
 
         val handled = state.handleEnterKey()
 
         assertTrue(handled)
-        assertEquals("• Hello \n• world", state.value.text)
+        assertEquals("${indent}• Hello \n${indent}• world", state.value.text)
     }
 
     @Test
@@ -65,8 +67,8 @@ class RichTextListBehaviorTest {
 
         state.applyFormattingAction(FormattingAction.BulletList)
 
-        assertEquals("• ", state.value.text)
-        assertEquals(TextRange(2), state.value.selection)
+        assertEquals("${indent}• ", state.value.text)
+        assertEquals(TextRange(indent.length + 2), state.value.selection)
     }
 
     @Test
@@ -76,8 +78,8 @@ class RichTextListBehaviorTest {
 
         state.applyFormattingAction(FormattingAction.NumberedList)
 
-        assertEquals("1. Example", state.value.text)
-        assertEquals(TextRange(baseText.length + 3), state.value.selection)
+        assertEquals("${indent}1. Example", state.value.text)
+        assertEquals(TextRange(baseText.length + 3 + indent.length), state.value.selection)
     }
 
     private fun plainValue(text: String, selection: Int): RichTextValue {


### PR DESCRIPTION
## Summary
- add highlight and text colour support to rich text styles and persistence
- expand the editor toolbar with highlight and colour pickers while indenting list items
- suppress the fallback summarizer banner and strip Title lines from fallback summaries

## Testing
- ./gradlew test --rerun-tasks --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68dcbb9742508320b9aebc647457d760