### PR TITLE
Adjust calendar event summaries to omit sensitive metadata

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -663,29 +663,16 @@ class NoteViewModel(
                 }
             }.trim()
         }
-        val zoneId = runCatching { java.time.ZoneId.of(event.timeZone) }
-            .getOrDefault(java.time.ZoneId.systemDefault())
-        val start = java.time.Instant.ofEpochMilli(event.start).atZone(zoneId)
-        val end = java.time.Instant.ofEpochMilli(event.end).atZone(zoneId)
-        val formatter = java.time.format.DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
+        if (trimmedContent.isEmpty()) {
+            return ""
+        }
         return buildString {
             if (trimmedTitle.isNotEmpty()) {
                 append("Title: ")
                 append(trimmedTitle)
-                append('\n')
-            }
-            append("Event from ")
-            append(start.format(formatter))
-            append(" to ")
-            append(end.format(formatter))
-            if (!event.location.isNullOrBlank()) {
-                append(" at ")
-                append(event.location)
-            }
-            if (trimmedContent.isNotEmpty()) {
                 append("\n\n")
-                append(trimmedContent)
             }
+            append(trimmedContent)
         }.trim()
     }
 

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -276,25 +276,27 @@ fun NoteListItem(note: Note, onClick: () -> Unit, modifier: Modifier = Modifier)
                 color = MaterialTheme.colors.primary,
                 modifier = Modifier.padding(top = 2.dp)
             )
-            event.location?.takeIf { it.isNotBlank() }?.let { location ->
-                val locationDisplay = rememberEventLocationDisplay(location)
-                Text(
-                    text = locationDisplay?.name ?: location,
-                    style = MaterialTheme.typography.body2,
-                    modifier = Modifier.padding(top = 2.dp),
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                val secondary = locationDisplay?.address
-                    ?.takeIf { !it.equals(locationDisplay.name, ignoreCase = true) }
-                secondary?.let { address ->
+            if (!note.isLocked) {
+                event.location?.takeIf { it.isNotBlank() }?.let { location ->
+                    val locationDisplay = rememberEventLocationDisplay(location)
                     Text(
-                        text = address,
-                        style = MaterialTheme.typography.caption,
-                        modifier = Modifier.padding(top = 1.dp),
+                        text = locationDisplay?.name ?: location,
+                        style = MaterialTheme.typography.body2,
+                        modifier = Modifier.padding(top = 2.dp),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    val secondary = locationDisplay?.address
+                        ?.takeIf { !it.equals(locationDisplay.name, ignoreCase = true) }
+                    secondary?.let { address ->
+                        Text(
+                            text = address,
+                            style = MaterialTheme.typography.caption,
+                            modifier = Modifier.padding(top = 1.dp),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- remove calendar date, time, and location details from the summarizer input so only note comments are summarized
- skip summary generation for calendar entries that have no comment text
- hide event location rows in the note list when the note is locked

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de608d383883209be26293cca53f23