### PR TITLE
Update launcher icon background color to white

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,4 +1,4 @@
 <resources>
     <color name="fab_color">#EC1A55</color>
-    <color name="ic_launcher_background">#FFC0CB</color>
+    <color name="ic_launcher_background">#FFFFFF</color>
 </resources>


### PR DESCRIPTION
## Summary
- set the launcher icon background color resource to pure white to remove the previous pink tint

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de760ff03483208b160cd5498dbd14