### PR TITLE
Stop auto-adding checklist items while typing

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/ChecklistScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/ChecklistScreen.kt
@@ -197,11 +197,6 @@ private fun ChecklistEditorScreen(
                         onFocusHandled = { pendingFocusId = null },
                         onTextChange = { text ->
                             items[index] = item.copy(text = text)
-                            if (index == items.lastIndex && text.isNotBlank()) {
-                                val newItem = EditableChecklistItem(id = nextId(), text = "", isChecked = false)
-                                items.add(newItem)
-                                pendingFocusId = newItem.id
-                            }
                         },
                         onAddBelow = { initialText ->
                             val newItem = EditableChecklistItem(


### PR DESCRIPTION
## Summary
- stop the checklist editor from creating a new blank item whenever the last item becomes non-empty so entries are only added explicitly

## Testing
- ./gradlew testDebugUnitTest

------
https://chatgpt.com/codex/tasks/task_e_68de9e05f8488320990eefd4ba7489ee