### PR TITLE
Secure PIN storage with hashed persistence

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -181,6 +181,7 @@ dependencies {
     implementation 'ai.djl.android:tokenizer-native:0.33.0'
     implementation 'ai.djl.huggingface:tokenizers:0.33.0'
     implementation 'com.getkeepsafe.relinker:relinker:1.4.5'
+    implementation 'androidx.security:security-crypto:1.1.0-alpha06'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
 
@@ -197,6 +198,7 @@ dependencies {
     testImplementation 'androidx.test:core:1.5.0'
     testImplementation 'androidx.test.ext:junit:1.1.5'
     testImplementation 'org.robolectric:robolectric:4.12.1'
+    testImplementation 'org.robolectric:android-all-instrumented:14-robolectric-10818077-i6'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation 'androidx.test:core:1.5.0'

--- a/app/src/main/java/com/example/starbucknotetaker/AttachmentStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/AttachmentStore.kt
@@ -10,7 +10,7 @@ import javax.crypto.spec.GCMParameterSpec
 import javax.crypto.spec.PBEKeySpec
 import javax.crypto.spec.SecretKeySpec
 
-class AttachmentStore(private val context: Context) {
+class AttachmentStore(private val context: Context) : PinAttachmentStore {
     private val directory: File = File(context.filesDir, "attachments")
     private val secureRandom = SecureRandom()
 
@@ -60,7 +60,7 @@ class AttachmentStore(private val context: Context) {
         runCatching { attachmentFile(id).takeIf(File::exists)?.delete() }
     }
 
-    fun reencryptAttachment(oldPin: String, newPin: String, id: String): Boolean {
+    override fun reencryptAttachment(oldPin: String, newPin: String, id: String): Boolean {
         val plain = openAttachment(oldPin, id) ?: return false
         saveAttachment(newPin, plain, id)
         return true

--- a/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/EncryptedNoteStore.kt
@@ -21,13 +21,13 @@ import java.util.Locale
 class EncryptedNoteStore(
     private val context: Context,
     private val attachmentStore: AttachmentStore = AttachmentStore(context),
-) {
+) : PinNoteStore {
     private val file = File(context.filesDir, "notes.enc")
     companion object {
         private const val VERSION = 1
     }
 
-    fun loadNotes(pin: String): List<Note> {
+    override fun loadNotes(pin: String): List<Note> {
         if (!file.exists()) return emptyList()
         val bytes = file.readBytes()
         return loadNotesFromBytes(bytes, pin)
@@ -168,7 +168,7 @@ class EncryptedNoteStore(
         return notes
     }
 
-    fun saveNotes(notes: List<Note>, pin: String) {
+    override fun saveNotes(notes: List<Note>, pin: String) {
         val arr = JSONArray()
         notes.forEach { note ->
             val obj = JSONObject()

--- a/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinManager.kt
@@ -2,30 +2,67 @@ package com.example.starbucknotetaker
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.security.crypto.EncryptedSharedPreferences
+import androidx.security.crypto.MasterKey
+import java.security.SecureRandom
+import java.util.Base64
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
 
-class PinManager(context: Context) {
-    private val prefs: SharedPreferences = context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
+class PinManager internal constructor(
+    private val appContext: Context,
+    private val prefs: SharedPreferences,
+    private val legacyPrefs: SharedPreferences,
+    private val attachmentStoreFactory: (Context) -> PinAttachmentStore,
+    private val noteStoreFactory: (Context, PinAttachmentStore) -> PinNoteStore,
+) {
 
-    fun isPinSet(): Boolean = prefs.contains(KEY_PIN)
+    constructor(context: Context) : this(
+        context.applicationContext,
+        createEncryptedPreferences(context.applicationContext),
+        context.applicationContext.getSharedPreferences(LEGACY_PREFS_NAME, Context.MODE_PRIVATE),
+        { AttachmentStore(it) },
+        { ctx, attachments ->
+            val concrete = attachments as? AttachmentStore ?: AttachmentStore(ctx)
+            EncryptedNoteStore(ctx, concrete)
+        }
+    )
 
-    fun setPin(pin: String) {
-        prefs.edit().putString(KEY_PIN, pin).apply()
+    init {
+        migrateLegacyPinIfNeeded()
     }
 
-    fun getStoredPin(): String? = prefs.getString(KEY_PIN, null)
+    fun isPinSet(): Boolean = prefs.contains(KEY_PIN_HASH) || legacyPrefs.contains(KEY_PIN_LEGACY)
 
-    fun checkPin(pin: String): Boolean = prefs.getString(KEY_PIN, null) == pin
+    fun setPin(pin: String) {
+        val salt = generateSalt()
+        val hash = hashPin(pin, salt)
+        prefs.edit()
+            .putString(KEY_PIN_HASH, hash)
+            .putString(KEY_PIN_SALT, encode(salt))
+            .putInt(KEY_PIN_LENGTH, pin.length)
+            .remove(KEY_PIN_LEGACY)
+            .apply()
+        legacyPrefs.edit().remove(KEY_PIN_LEGACY).apply()
+    }
 
-    fun getPinLength(): Int = prefs.getString(KEY_PIN, null)?.length ?: 0
+    fun getStoredPin(): String? = prefs.getString(KEY_PIN_HASH, null)
+
+    fun checkPin(pin: String): Boolean {
+        val salt = prefs.getString(KEY_PIN_SALT, null) ?: return false
+        val stored = prefs.getString(KEY_PIN_HASH, null) ?: return false
+        val computed = hashPin(pin, decode(salt) ?: return false)
+        return constantTimeEquals(stored, computed)
+    }
+
+    fun getPinLength(): Int = prefs.getInt(KEY_PIN_LENGTH, 0)
 
     fun updatePin(oldPin: String, newPin: String): Boolean {
-        val stored = prefs.getString(KEY_PIN, null) ?: return false
-        return if (stored == oldPin) {
-            prefs.edit().putString(KEY_PIN, newPin).apply()
-            true
-        } else {
-            false
+        if (!checkPin(oldPin)) {
+            return false
         }
+        setPin(newPin)
+        return true
     }
 
     fun isBiometricEnabled(): Boolean = prefs.getBoolean(KEY_BIOMETRIC_ENABLED, false)
@@ -36,13 +73,101 @@ class PinManager(context: Context) {
 
     fun clearPin() {
         prefs.edit()
-            .remove(KEY_PIN)
+            .remove(KEY_PIN_HASH)
+            .remove(KEY_PIN_SALT)
+            .remove(KEY_PIN_LENGTH)
             .remove(KEY_BIOMETRIC_ENABLED)
+            .remove(KEY_PIN_LEGACY)
             .apply()
+        legacyPrefs.edit().remove(KEY_PIN_LEGACY).apply()
+    }
+
+    private fun migrateLegacyPinIfNeeded() {
+        if (prefs.contains(KEY_PIN_HASH)) {
+            return
+        }
+        val legacyPin = legacyPrefs.getString(KEY_PIN_LEGACY, null) ?: return
+        val salt = generateSalt()
+        val hash = hashPin(legacyPin, salt)
+        reencryptStoredData(legacyPin, hash)
+        prefs.edit()
+            .putString(KEY_PIN_HASH, hash)
+            .putString(KEY_PIN_SALT, encode(salt))
+            .putInt(KEY_PIN_LENGTH, legacyPin.length)
+            .remove(KEY_PIN_LEGACY)
+            .apply()
+        legacyPrefs.edit().remove(KEY_PIN_LEGACY).apply()
+    }
+
+    private fun reencryptStoredData(oldPin: String, newPin: String) {
+        runCatching {
+            val attachmentStore = attachmentStoreFactory(appContext)
+            val noteStore = noteStoreFactory(appContext, attachmentStore)
+            val notes = noteStore.loadNotes(oldPin)
+            val attachmentIds = notes.flatMap { note ->
+                note.images.mapNotNull { it.attachmentId } +
+                    note.files.mapNotNull { it.attachmentId }
+            }.toSet()
+            attachmentIds.forEach { id ->
+                runCatching { attachmentStore.reencryptAttachment(oldPin, newPin, id) }
+            }
+            noteStore.saveNotes(notes, newPin)
+        }
+    }
+
+    private fun hashPin(pin: String, salt: ByteArray): String {
+        val spec = PBEKeySpec(pin.toCharArray(), salt, HASH_ITERATIONS, HASH_KEY_LENGTH)
+        val factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256")
+        val hash = factory.generateSecret(spec).encoded
+        return encode(hash)
+    }
+
+    private fun generateSalt(): ByteArray {
+        val bytes = ByteArray(SALT_LENGTH)
+        SecureRandom().nextBytes(bytes)
+        return bytes
+    }
+
+    private fun encode(bytes: ByteArray): String =
+        Base64.getEncoder().encodeToString(bytes)
+
+    private fun decode(value: String): ByteArray? =
+        runCatching { Base64.getDecoder().decode(value) }.getOrNull()
+
+    private fun constantTimeEquals(a: String, b: String): Boolean {
+        val aBytes = a.toByteArray()
+        val bBytes = b.toByteArray()
+        if (aBytes.size != bBytes.size) return false
+        var result = 0
+        for (i in aBytes.indices) {
+            result = result or (aBytes[i].toInt() xor bBytes[i].toInt())
+        }
+        return result == 0
     }
 
     companion object {
-        private const val KEY_PIN = "pin"
+        private const val PREFS_NAME = "pin_prefs_secure"
+        private const val LEGACY_PREFS_NAME = "pin_prefs"
+        private const val KEY_PIN_HASH = "pin_hash"
+        private const val KEY_PIN_SALT = "pin_salt"
+        private const val KEY_PIN_LENGTH = "pin_length"
+        private const val KEY_PIN_LEGACY = "pin"
         private const val KEY_BIOMETRIC_ENABLED = "biometric_enabled"
+        private const val HASH_ITERATIONS = 10000
+        private const val HASH_KEY_LENGTH = 256
+        private const val SALT_LENGTH = 16
+
+        private fun createEncryptedPreferences(context: Context): SharedPreferences {
+            val masterKey = MasterKey.Builder(context)
+                .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
+                .build()
+            return EncryptedSharedPreferences.create(
+                context,
+                PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        }
     }
 }

--- a/app/src/main/java/com/example/starbucknotetaker/PinStorageAdapters.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/PinStorageAdapters.kt
@@ -1,0 +1,10 @@
+package com.example.starbucknotetaker
+
+interface PinAttachmentStore {
+    fun reencryptAttachment(oldPin: String, newPin: String, id: String): Boolean
+}
+
+interface PinNoteStore {
+    fun loadNotes(pin: String): List<Note>
+    fun saveNotes(notes: List<Note>, pin: String)
+}

--- a/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/PinScreens.kt
@@ -119,7 +119,10 @@ fun PinSetupScreen(pinManager: PinManager, onDone: (String) -> Unit) {
                         hideKeyboard()
                         focusManager.clearFocus(force = true)
                         pinManager.setPin(pin)
-                        onDone(pin)
+                        val stored = pinManager.getStoredPin()
+                        if (stored != null) {
+                            onDone(stored)
+                        }
                     } else {
                         error = "PINs did not match"
                         firstPin = null
@@ -179,7 +182,10 @@ fun PinEnterScreen(pinManager: PinManager, onSuccess: (String) -> Unit) {
                             if (pinManager.checkPin(input)) {
                                 hideKeyboard()
                                 focusManager.clearFocus(force = true)
-                                onSuccess(input)
+                                val stored = pinManager.getStoredPin()
+                                if (stored != null) {
+                                    onSuccess(stored)
+                                }
                             } else {
                                 error = true
                             }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -437,13 +437,19 @@ fun SettingsScreen(
                                     pinChangeMessage = null
                                 }
                                 pinManager.updatePin(currentPin, newPin) -> {
-                                    onPinChanged(newPin)
-                                    pinChangeError = null
-                                    pinChangeMessage = "PIN updated successfully."
-                                    currentPin = ""
-                                    newPin = ""
-                                    confirmPin = ""
-                                    currentPinVerified = false
+                                    val stored = pinManager.getStoredPin()
+                                    if (stored != null) {
+                                        onPinChanged(stored)
+                                        pinChangeError = null
+                                        pinChangeMessage = "PIN updated successfully."
+                                        currentPin = ""
+                                        newPin = ""
+                                        confirmPin = ""
+                                        currentPinVerified = false
+                                    } else {
+                                        pinChangeError = "Unable to read updated PIN."
+                                        pinChangeMessage = null
+                                    }
                                 }
                                 else -> {
                                     pinChangeError = "Unable to update PIN. Please verify your current PIN."

--- a/app/src/test/java/com/example/starbucknotetaker/PinManagerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/PinManagerTest.kt
@@ -1,0 +1,113 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.After
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.io.File
+
+@RunWith(RobolectricTestRunner::class)
+class PinManagerTest {
+
+    private lateinit var context: Context
+
+    @Before
+    fun setUp() {
+        context = ApplicationProvider.getApplicationContext()
+        context.getSharedPreferences("pin_prefs_secure", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
+            .edit()
+            .clear()
+            .commit()
+        File(context.filesDir, "notes.enc").delete()
+        val attachmentsDir = File(context.filesDir, "attachments")
+        if (attachmentsDir.exists()) {
+            attachmentsDir.deleteRecursively()
+        }
+    }
+
+    @After
+    fun tearDown() {
+        File(context.filesDir, "notes.enc").delete()
+        val attachmentsDir = File(context.filesDir, "attachments")
+        if (attachmentsDir.exists()) {
+            attachmentsDir.deleteRecursively()
+        }
+    }
+
+    @Test
+    fun setPinStoresHashedValue() {
+        val manager = PinManager(context)
+
+        manager.setPin("1234")
+
+        assertTrue(manager.checkPin("1234"))
+        assertFalse(manager.checkPin("0000"))
+        assertEquals(4, manager.getPinLength())
+        val stored = manager.getStoredPin()
+        assertNotNull(stored)
+        assertNotEquals("1234", stored)
+    }
+
+    @Test
+    fun updatePinRehashesValue() {
+        val manager = PinManager(context)
+        manager.setPin("1234")
+        val previous = manager.getStoredPin()
+
+        val updated = manager.updatePin("1234", "5678")
+
+        assertTrue(updated)
+        assertTrue(manager.checkPin("5678"))
+        assertFalse(manager.checkPin("1234"))
+        assertEquals(4, manager.getPinLength())
+        val stored = manager.getStoredPin()
+        assertNotNull(stored)
+        assertNotEquals("5678", stored)
+        assertNotEquals(previous, stored)
+    }
+
+    @Test
+    fun migratesLegacyPinAndReencryptsData() {
+        val legacyPin = "2468"
+        val legacyPrefs = context.getSharedPreferences("pin_prefs", Context.MODE_PRIVATE)
+        legacyPrefs.edit().putString("pin", legacyPin).commit()
+
+        val attachmentStore = AttachmentStore(context)
+        val noteStore = EncryptedNoteStore(context, attachmentStore)
+        val attachmentData = "hello".toByteArray()
+        val attachmentId = attachmentStore.saveAttachment(legacyPin, attachmentData, "legacyAttachment")
+        val note = Note(
+            id = 1L,
+            title = "Legacy",
+            content = "Content",
+            images = listOf(NoteImage(attachmentId = attachmentId))
+        )
+        noteStore.saveNotes(listOf(note), legacyPin)
+
+        val manager = PinManager(context)
+
+        assertTrue(manager.checkPin(legacyPin))
+        val stored = manager.getStoredPin()
+        assertNotNull(stored)
+        assertNotEquals(legacyPin, stored)
+
+        val reloaded = noteStore.loadNotes(stored!!)
+        assertEquals(1, reloaded.size)
+        val reloadedAttachment = attachmentStore.openAttachment(stored, attachmentId)
+        assertNotNull(reloadedAttachment)
+        assertArrayEquals(attachmentData, reloadedAttachment)
+    }
+}


### PR DESCRIPTION
## Summary
- replace plain-text PIN storage with EncryptedSharedPreferences and PBKDF2 hashed values in PinManager, including legacy migration and attachment re-encryption
- update PIN UI flows to work with hashed values and add storage abstractions for attachment and note stores
- add Robolectric coverage for hashed PIN behaviour and migration scenarios

## Testing
- `./gradlew test` *(fails: Robolectric attempted to download android-all-instrumented and network access is unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68de902f8d9c832093ecaba72a621896