### PR TITLE
Run fallback summarization asynchronously

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/NoteViewModelTest.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.verify
 import org.junit.Assert.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -35,6 +36,7 @@ class NoteViewModelTest {
     @Test
     fun addNoteUpdatesSummaryFromSummarizer() = runTest(dispatcher.scheduler) {
         val summarizer = mock<Summarizer>()
+        whenever(summarizer.quickFallbackSummary(any())).thenReturn("Quick placeholder")
         whenever(summarizer.fallbackSummary(any(), anyOrNull())).thenReturn(NoteNatureType.GENERAL_NOTE.humanReadable)
         whenever(summarizer.summarize(any())).thenReturn("mocked summary")
         whenever(summarizer.consumeDebugTrace()).thenReturn(emptyList())
@@ -51,11 +53,13 @@ class NoteViewModelTest {
             emptyList(),
         )
 
-        assertEquals(NoteNatureType.GENERAL_NOTE.humanReadable, viewModel.notes[0].summary)
+        assertEquals("Quick placeholder", viewModel.notes[0].summary)
+        verify(summarizer).quickFallbackSummary(any())
 
         advanceUntilIdle()
 
         assertEquals("mocked summary", viewModel.notes[0].summary)
+        verify(summarizer).fallbackSummary(any(), anyOrNull())
     }
 
     @Test

--- a/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/SummarizerTest.kt
@@ -44,7 +44,7 @@ class SummarizerTest {
     }
 
     @Test
-    fun fallbackSummaryReturnsFirstTwoLines() {
+    fun fallbackSummaryReturnsFirstTwoLines() = runBlocking {
         val summarizer = Summarizer(context, nativeLoader = { false }, debugSink = { })
         val text = """
             Security updates require MFA for all accounts.


### PR DESCRIPTION
## Summary
- convert `Summarizer.fallbackSummary` into a suspend function and add a lightweight preview helper
- update `NoteViewModel` to use quick placeholders and launch coroutines for fallback and generative summaries
- adjust unit tests for the new asynchronous summarization workflow

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68de923decd08320866a2a0ad1250ee0