### PR TITLE
Expand training data and evaluation in build notebook

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -5,7 +5,7 @@
                 "numpy==2.0.2" "protobuf==5.29.1" "ml-dtypes>=0.5.0" \
                 "datasets==3.1.0"
 
-import os, zipfile, gc
+import os, zipfile, gc, random
 os.environ["TOKENIZERS_PARALLELISM"] = "false"
 os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 
@@ -35,35 +35,602 @@ tokenizer = T5TokenizerFast.from_pretrained(MODEL_ID)
 base_model = TFT5ForConditionalGeneration.from_pretrained(MODEL_ID)
 
 # Keep memory small
-MAX_SRC_LEN = 64
-MAX_TGT_LEN = 64
+MAX_SRC_LEN = 128
+MAX_TGT_LEN = 96
 D_MODEL = base_model.config.d_model
 
 # ---------- Load note → type-first summary dataset ----------
-examples = [
-    {
-        "note": "Latte with oat milk, 2x vanilla pumps, add whipped cream. Customer noted dairy sensitivity and requested extra napkins.",
-        "summary": "drink: latte (oat milk), modifiers: 2 vanilla, extras: whipped cream, requests: dairy sensitive, napkins=extra",
-    },
-    {
-        "note": "Order for mobile pickup: two cake pops, one triple espresso over ice, double blended. Customer wants a sticker on each cup.",
-        "summary": "drink: triple espresso (iced, double blend), food: 2 cake pops, requests: sticker per cup",
-    },
-    {
-        "note": "Daily batch note - pastry case restock counted 14 croissants, 9 blueberry muffins, 6 lemon loaves.",
-        "summary": "inventory: croissants=14, blueberry muffins=9, lemon loaves=6",
-    },
-    {
-        "note": "Training reminder: review cold brew tapping steps with new partner Ava and sign completion log.",
-        "summary": "task: training review, subject: cold brew tap, assignee: Ava, action: sign completion log",
-    },
+SEED = 42
+random.seed(SEED)
+np.random.seed(SEED)
+tf.random.set_seed(SEED)
+
+NOTE_TYPES = [
+    "PERSONAL_DAILY_LIFE",
+    "FINANCE_LEGAL",
+    "SELF_IMPROVEMENT",
+    "HEALTH_WELLNESS",
+    "EDUCATION_LEARNING",
+    "HOME_FAMILY",
+    "WORK_PROJECT",
+    "MEETING_RECAP",
+    "SHOPPING_LIST",
+    "REMINDER",
+    "TRAVEL_LOG",
+    "FOOD_RECIPE",
+    "CREATIVE_WRITING",
+    "TECHNICAL_REFERENCE",
+    "GENERAL_NOTE",
 ]
 
-raw_dataset = Dataset.from_list(examples)
-PROMPT = "summarize the note type and key counts: "
+def format_summary(category, entities):
+    detail_parts = [f"{key}: {value}" for key, value in entities]
+    return f"{category} | " + "; ".join(detail_parts)
+
+def normalize_sentence_ending(text):
+    text = text.strip()
+    if not text:
+        return text
+    if text[-1] in ".!?":
+        return text
+    return text + "."
+
+def augment_note_variations(note, max_variants=3):
+    base = normalize_sentence_ending(note)
+    sentences = [s.strip() for s in base.replace("\n", " ").split(".") if s.strip()]
+    variations = [base]
+    if sentences:
+        rotated = sentences[1:] + sentences[:1]
+        rotated_text = normalize_sentence_ending(". ".join(rotated))
+        if rotated_text not in variations:
+            variations.append(rotated_text)
+    prefixed = normalize_sentence_ending(f"Reminder: {base}")
+    if prefixed not in variations:
+        variations.append(prefixed)
+    expanded = []
+    for variant in variations:
+        variant = variant.replace("  ", " ").strip()
+        if variant not in expanded:
+            expanded.append(variant)
+    return expanded[:max_variants]
+
+category_examples = {
+    "PERSONAL_DAILY_LIFE": [
+        {
+            "note": "Morning check-in: Woke at 6:30am for a jog around Green Lake, logged 3.2 miles. Packed healthy lunch of quinoa bowl and prepped cold brew concentrate for tomorrow.",
+            "entities": [
+                ("focus", "morning routine reset"),
+                ("activities", "3.2 mile jog, lunch prep, cold brew setup"),
+                ("follow_up", "measure concentrate strength in the morning"),
+            ],
+        },
+        {
+            "note": "Evening wind-down: decluttered studio desk, filed April receipts, reset espresso machine for AM shots. Noted that roommate Maya borrowed the travel mug again.",
+            "entities": [
+                ("focus", "end-of-day organization"),
+                ("key_entities", "desk, April receipts, espresso machine"),
+                ("action_items", "remind Maya about the travel mug"),
+            ],
+        },
+        {
+            "note": "Weekend planning list: brunch with dad at 10, drop off reusable cups at community swap, schedule haircut before the Seattle rainstorm hits.",
+            "entities": [
+                ("focus", "Saturday personal commitments"),
+                ("events", "brunch with dad, cup swap, haircut booking"),
+                ("timing", "prioritize before forecasted rain"),
+            ],
+        },
+        {
+            "note": "Self-care log: listened to new jazz playlist while brewing Ethiopian pour-over, journaled three gratitude entries, diffused cedarwood oil in the living room.",
+            "entities": [
+                ("focus", "evening self-care"),
+                ("sensory", "jazz playlist, cedarwood diffusion"),
+                ("actions", "pour-over brew, gratitude journaling"),
+            ],
+        },
+    ],
+    "FINANCE_LEGAL": [
+        {
+            "note": "Budget review session: reconciled March cafe tips with bank deposit, set aside $120 for partner appreciation gifts, flagged IRS letter needing signature by Friday.",
+            "entities": [
+                ("focus", "monthly cashflow"),
+                ("amounts", "tips reconciliation, $120 appreciation fund"),
+                ("deadline", "sign IRS letter by Friday"),
+            ],
+        },
+        {
+            "note": "Expense audit: cross-checked milk delivery invoices against Clover exports, found $48 discrepancy on 4/18 order, emailed vendor support for credit memo.",
+            "entities": [
+                ("focus", "invoice validation"),
+                ("issue", "$48 shortage on April 18 delivery"),
+                ("next_steps", "await vendor credit memo"),
+            ],
+        },
+        {
+            "note": "Legal compliance reminder: updated food handler permit roster, noted Jayden's certificate expires 05/30, scheduled renewal training in SharePoint calendar.",
+            "entities": [
+                ("focus", "permit compliance"),
+                ("key_entities", "Jayden permit expiring 05/30"),
+                ("action_items", "complete renewal training booking"),
+            ],
+        },
+        {
+            "note": "Quarterly forecast huddle: projected utility increase of 7%, renegotiated waste pickup contract, documented agreement in LegalHub folder.",
+            "entities": [
+                ("focus", "store financial planning"),
+                ("changes", "utilities +7%, waste contract updated"),
+                ("documentation", "noted in LegalHub"),
+            ],
+        },
+    ],
+    "SELF_IMPROVEMENT": [
+        {
+            "note": "Personal growth sprint: completed leadership podcast episode during commute, practiced milk art patterns for 20 minutes, noted confidence boost when coaching new barista.",
+            "entities": [
+                ("focus", "leadership + craft skills"),
+                ("activities", "podcast learning, milk art drills"),
+                ("reflection", "confidence improved while mentoring"),
+            ],
+        },
+        {
+            "note": "Learning log: finished chapter on inclusive hiring in partner playbook, drafted two feedback prompts to use in next shift debrief, set reminder to roleplay responses with mentor.",
+            "entities": [
+                ("focus", "inclusive leadership"),
+                ("achievements", "chapter complete, feedback prompts drafted"),
+                ("follow_up", "roleplay with mentor"),
+            ],
+        },
+        {
+            "note": "Goal tracker: set SMART objective to reduce drive-thru times by 10 seconds, reviewed last month's metrics, asked Alicia for accountability check on Tuesdays.",
+            "entities": [
+                ("focus", "performance coaching"),
+                ("targets", "-10s drive-thru time"),
+                ("support", "Alicia providing weekly check-in"),
+            ],
+        },
+        {
+            "note": "Skill sharpening: practiced calm conflict language from workshop, wrote down three phrases to defuse rush line tension, scheduled reflection post-shift.",
+            "entities": [
+                ("focus", "communication practice"),
+                ("tools", "conflict phrases notebook"),
+                ("timing", "post-shift reflection scheduled"),
+            ],
+        },
+    ],
+    "HEALTH_WELLNESS": [
+        {
+            "note": "Wellness check: recorded hydration at 72 oz water, swapped second mocha for herbal tea, booked telehealth visit for recurring wrist strain.",
+            "entities": [
+                ("focus", "hydration + ergonomic care"),
+                ("metrics", "72 oz water"),
+                ("follow_up", "telehealth wrist consult"),
+            ],
+        },
+        {
+            "note": "Shift stamina log: stretched before opening, wore new compression socks, noted energy dip around 2pm after missed snack.",
+            "entities": [
+                ("focus", "energy management"),
+                ("supports", "pre-shift stretch, compression socks"),
+                ("observations", "2pm energy dip due to missed snack"),
+            ],
+        },
+        {
+            "note": "Mental health note: used Calm breathing track during break, journaled about guest interaction stress, plan to discuss with therapist on Thursday.",
+            "entities": [
+                ("focus", "stress regulation"),
+                ("techniques", "breathing track, journaling"),
+                ("plan", "therapist conversation Thursday"),
+            ],
+        },
+        {
+            "note": "Nutrition prep: meal-prepped roasted veggies and tofu bowls for three shifts, logged macros in app, reminded self to pack electrolyte tablets.",
+            "entities": [
+                ("focus", "shift fueling"),
+                ("prep", "three tofu bowls ready"),
+                ("reminder", "bring electrolyte tablets"),
+            ],
+        },
+    ],
+    "EDUCATION_LEARNING": [
+        {
+            "note": "Training recap: completed Origin Espresso module, passed quiz with 92%, shared tasting notes comparing Verona vs Espresso Roast with team.",
+            "entities": [
+                ("focus", "coffee mastery coursework"),
+                ("achievement", "Origin Espresso module 92%"),
+                ("knowledge_share", "Verona vs Espresso Roast notes"),
+            ],
+        },
+        {
+            "note": "Learning ladder: scheduled Latte Art 201 class, printed practice worksheets, asked store manager for coverage during webinar.",
+            "entities": [
+                ("focus", "continuing education"),
+                ("actions", "class scheduled, worksheets printed"),
+                ("support", "coverage requested from manager"),
+            ],
+        },
+        {
+            "note": "Study session: reviewed beverage build flashcards, quizzed coworker on refreshers ratios, bookmarked knowledge base article on syrup pumps for new drinks.",
+            "entities": [
+                ("focus", "recipe memorization"),
+                ("methods", "flashcards, peer quiz"),
+                ("resources", "syrup pump reference saved"),
+            ],
+        },
+        {
+            "note": "Course progress: enrolled in Starbucks Global Academy sustainability track, completed lesson on water stewardship, drafted key takeaways to share in next partner meeting.",
+            "entities": [
+                ("focus", "sustainability training"),
+                ("status", "lesson complete"),
+                ("action_items", "share takeaways in meeting"),
+            ],
+        },
+    ],
+    "HOME_FAMILY": [
+        {
+            "note": "Family calendar: coordinated with sister Lena about hosting Mother's Day brunch, assigned grocery pickups, reserved family table at local cafe.",
+            "entities": [
+                ("focus", "family event planning"),
+                ("collaborators", "sister Lena"),
+                ("tasks", "grocery pickup, table reservation"),
+            ],
+        },
+        {
+            "note": "Home maintenance log: replaced cabin filter in Subaru, scheduled plumber for slow sink drain Friday 3pm, updated shared chores board.",
+            "entities": [
+                ("focus", "household upkeep"),
+                ("repairs", "sink drain appointment Friday 3pm"),
+                ("updates", "cabin filter change, chores board"),
+            ],
+        },
+        {
+            "note": "Childcare coordination: confirmed daycare pickup swap with neighbor Jorge, packed extra snacks for Emma's field trip, left car seat in foyer.",
+            "entities": [
+                ("focus", "childcare logistics"),
+                ("arrangements", "pickup swap with Jorge"),
+                ("prep", "snacks packed, car seat ready"),
+            ],
+        },
+        {
+            "note": "Household finance chat: reviewed joint budget with partner, agreed to pause streaming subscriptions, set reminder to compare power providers next week.",
+            "entities": [
+                ("focus", "family budgeting"),
+                ("decisions", "pause streaming services"),
+                ("follow_up", "research power providers"),
+            ],
+        },
+    ],
+    "WORK_PROJECT": [
+        {
+            "note": "Project Voyager: mapped out rollout timeline for new cold foam station, assigned hardware checks to Malik, drafted training deck outline.",
+            "entities": [
+                ("focus", "cold foam station launch"),
+                ("assignments", "Malik handles hardware checks"),
+                ("deliverables", "training deck outline drafted"),
+            ],
+        },
+        {
+            "note": "Drive-thru revamp: compiled partner feedback on headset static, escalated ticket to facilities, prototyped new greeting script in FigJam.",
+            "entities": [
+                ("focus", "drive-thru experience"),
+                ("issues", "headset static escalated"),
+                ("progress", "greeting script prototype"),
+            ],
+        },
+        {
+            "note": "Store remodel sprint: confirmed contractor start date 6/12, labeled backroom storage bins, coordinated coverage plan with DM.",
+            "entities": [
+                ("focus", "remodel preparation"),
+                ("timeline", "contractor begins 6/12"),
+                ("coordination", "coverage plan with district manager"),
+            ],
+        },
+        {
+            "note": "Digital menu pilot: reviewed analytics from test store, highlighted 18% uplift on breakfast sandwiches, scheduled sync with product manager Iris.",
+            "entities": [
+                ("focus", "digital menu analytics"),
+                ("metrics", "18% breakfast sandwich lift"),
+                ("next_steps", "sync with PM Iris"),
+            ],
+        },
+    ],
+    "MEETING_RECAP": [
+        {
+            "note": "Shift meeting recap: aligned on mobile order staging flow, assigned Riley to monitor warming oven temps, noted need to reorder grande lids.",
+            "entities": [
+                ("focus", "shift alignment"),
+                ("assignments", "Riley monitors oven temps"),
+                ("action_items", "reorder grande lids"),
+            ],
+        },
+        {
+            "note": "District call summary: DM praised store cleanliness scores, announced upcoming beverage launch training, requested weekly progress photos.",
+            "entities": [
+                ("focus", "district updates"),
+                ("highlights", "cleanliness recognition"),
+                ("follow_up", "send weekly progress photos"),
+            ],
+        },
+        {
+            "note": "Manager sync: reviewed labor forecast variance, decided to cross-train two partners on ovens, set follow-up for next Wednesday.",
+            "entities": [
+                ("focus", "labor planning"),
+                ("decisions", "cross-train two partners"),
+                ("timeline", "follow-up Wednesday"),
+            ],
+        },
+        {
+            "note": "Community board meeting: presented sustainability updates, secured permission for recycling signage, action to email design proofs by Monday.",
+            "entities": [
+                ("focus", "community engagement"),
+                ("outcomes", "recycling signage approved"),
+                ("next_steps", "email design proofs Monday"),
+            ],
+        },
+    ],
+    "SHOPPING_LIST": [
+        {
+            "note": "Weekly grocery run: oat milk 3 cartons, almond butter 2 jars, spinach, blueberries, cold brew filters, biodegradable soap refill.",
+            "entities": [
+                ("focus", "household grocery list"),
+                ("priority_items", "oat milk x3, almond butter x2"),
+                ("extras", "cold brew filters, soap refill"),
+            ],
+        },
+        {
+            "note": "Store supply restock: need 6 sleeves tall lids, 4 cases blonde roast beans, 2 boxes pastry bags, restock sanitizer concentrate.",
+            "entities": [
+                ("focus", "store supply order"),
+                ("quantities", "lids=6 sleeves, beans=4 cases"),
+                ("add_ons", "pastry bags, sanitizer"),
+            ],
+        },
+        {
+            "note": "Farmers market haul list: honeycrisp apples, basil bunches, goat cheese, seasonal tulips for counter display.",
+            "entities": [
+                ("focus", "market shopping"),
+                ("produce", "apples, basil, tulips"),
+                ("treats", "goat cheese feature"),
+            ],
+        },
+        {
+            "note": "Breakroom refresh: sparkling water variety pack, individually wrapped snacks, compostable utensils, label refills.",
+            "entities": [
+                ("focus", "partner lounge restock"),
+                ("beverages", "sparkling water pack"),
+                ("supplies", "compostable utensils, labels"),
+            ],
+        },
+    ],
+    "REMINDER": [
+        {
+            "note": "Reminder: submit Bean Stock enrollment by 05/15 and verify beneficiaries in Workday before the deadline.",
+            "entities": [
+                ("focus", "benefits enrollment"),
+                ("deadline", "submit Bean Stock by 05/15"),
+                ("action_items", "verify beneficiaries"),
+            ],
+        },
+        {
+            "note": "Quick reminder to defrost breakfast sandwiches tonight so opening shift isn't delayed, leave them in walk-in on labeled tray.",
+            "entities": [
+                ("focus", "prep reminder"),
+                ("task", "defrost breakfast sandwiches"),
+                ("timing", "move to walk-in tonight"),
+            ],
+        },
+        {
+            "note": "Ping: schedule partner check-ins with Sarah and Eli before Friday review cycle closes.",
+            "entities": [
+                ("focus", "people management"),
+                ("task", "book Sarah and Eli 1:1s"),
+                ("timeline", "before Friday review cycle"),
+            ],
+        },
+        {
+            "note": "Friendly nudge: replace water filter cartridge on the nitro tap after tonight's close.",
+            "entities": [
+                ("focus", "equipment upkeep"),
+                ("task", "swap nitro tap filter"),
+                ("timing", "after tonight's close"),
+            ],
+        },
+    ],
+    "TRAVEL_LOG": [
+        {
+            "note": "Seattle to Portland trip: departed 8:15am on Amtrak Cascades, tasted seasonal lattes at Pioneer Courthouse store, noted crowd insights for merchandising deck.",
+            "entities": [
+                ("focus", "research travel"),
+                ("timeline", "Amtrak departure 8:15am"),
+                ("insights", "seasonal latte crowd data"),
+            ],
+        },
+        {
+            "note": "Road trip log: stopped in Olympia for partner store visit, documented drive-thru layout photos, updated mileage reimbursement sheet.",
+            "entities": [
+                ("focus", "field visit"),
+                ("activities", "drive-thru photos, mileage logged"),
+                ("next_steps", "submit reimbursement"),
+            ],
+        },
+        {
+            "note": "Conference travel recap: checked into Austin hotel, attended sustainability panel at 3pm, networked with regional managers over dinner.",
+            "entities": [
+                ("focus", "conference itinerary"),
+                ("events", "sustainability panel 3pm"),
+                ("connections", "regional manager dinner"),
+            ],
+        },
+        {
+            "note": "Vacation journal: explored Kyoto coffee scene, sampled pour-over at % Arabica, collected latte art inspiration photos for team share.",
+            "entities": [
+                ("focus", "travel inspiration"),
+                ("highlights", "% Arabica pour-over"),
+                ("action_items", "share latte art photos"),
+            ],
+        },
+    ],
+    "FOOD_RECIPE": [
+        {
+            "note": "Recipe test: crafted honey lavender cold foam, steeped 2 tbsp lavender buds in 1 cup cream, blended with 1 oz honey syrup, tasted best on cold brew.",
+            "entities": [
+                ("focus", "signature beverage R&D"),
+                ("ingredients", "lavender, honey syrup, cream"),
+                ("result", "pairs with cold brew"),
+            ],
+        },
+        {
+            "note": "Pastry experiment: baked matcha shortbread with white chocolate chips, chilled dough 2 hours, yield 18 cookies, crowd favorite on tasting tray.",
+            "entities": [
+                ("focus", "pastry innovation"),
+                ("process", "2 hr chill, 18 cookie yield"),
+                ("feedback", "tasting tray favorite"),
+            ],
+        },
+        {
+            "note": "Meal prep instructions: slow cooker chili with black beans, fire roasted tomatoes, chipotle, simmer 6 hours, top with cilantro lime crema.",
+            "entities": [
+                ("focus", "batch cooking plan"),
+                ("key_ingredients", "black beans, chipotle, crema"),
+                ("timing", "simmer 6 hours"),
+            ],
+        },
+        {
+            "note": "Syrup development: created toasted marshmallow syrup using brown sugar, vanilla, sea salt; strained into squeeze bottles, label batch 04/22.",
+            "entities": [
+                ("focus", "syrup crafting"),
+                ("ingredients", "brown sugar, vanilla, sea salt"),
+                ("action_items", "label batch 04/22"),
+            ],
+        },
+    ],
+    "CREATIVE_WRITING": [
+        {
+            "note": "Poetic sketch: latte art swan mirrors sunrise commute, foam feathers tracing ambitions of the opening crew.",
+            "entities": [
+                ("focus", "poetic reflection"),
+                ("imagery", "latte art swan, sunrise commute"),
+                ("tone", "aspirational"),
+            ],
+        },
+        {
+            "note": "Short story prompt: a barista discovers an old recipe card tucked inside a burlap bean sack and unlocks memories of a traveler passing through.",
+            "entities": [
+                ("focus", "story concept"),
+                ("hook", "hidden recipe card"),
+                ("theme", "memory and connection"),
+            ],
+        },
+        {
+            "note": "Spoken word draft: verses about the rhythm of grinders, steam wands, and the heartbeat of community seats at 3pm lull.",
+            "entities": [
+                ("focus", "spoken word piece"),
+                ("motifs", "grinders, steam wands, community"),
+                ("mood", "mid-afternoon calm"),
+            ],
+        },
+        {
+            "note": "Storyboard idea: illustrated panels of partner connections, from early morning open to closing gratitude circle under string lights.",
+            "entities": [
+                ("focus", "visual narrative"),
+                ("scenes", "opening shift, closing gratitude circle"),
+                ("goal", "highlight partner bonds"),
+            ],
+        },
+    ],
+    "TECHNICAL_REFERENCE": [
+        {
+            "note": "Machine maintenance SOP: purge Mastrena lines for 6 seconds, run detergent cycle nightly, log pressure readings in Equipment Tracker tab.",
+            "entities": [
+                ("focus", "espresso machine upkeep"),
+                ("steps", "purge 6s, nightly detergent cycle"),
+                ("documentation", "update Equipment Tracker"),
+            ],
+        },
+        {
+            "note": "POS troubleshooting guide: if order screen freezes, perform soft reset holding top buttons 10s, verify network light solid green, escalate to IT if issue repeats.",
+            "entities": [
+                ("focus", "register support"),
+                ("procedure", "soft reset 10s, check network light"),
+                ("escalation", "contact IT on repeat"),
+            ],
+        },
+        {
+            "note": "Cold brew tap spec: pressure should read 35 psi, clean draft line weekly with peracetic solution, replace gasket quarterly.",
+            "entities": [
+                ("focus", "nitro tap standards"),
+                ("metrics", "pressure 35 psi"),
+                ("maintenance", "weekly clean, quarterly gasket"),
+            ],
+        },
+        {
+            "note": "Wifi setup reference: guest SSID StarbucksGuest, password rotates monthly via StoreNet, router reboot sequence power-down 30 seconds then restart modem first.",
+            "entities": [
+                ("focus", "network configuration"),
+                ("credentials", "StarbucksGuest SSID"),
+                ("steps", "restart modem then router"),
+            ],
+        },
+    ],
+    "GENERAL_NOTE": [
+        {
+            "note": "Captured customer compliment for partner Jamie praising patient tea recommendations during rush.",
+            "entities": [
+                ("focus", "customer kudos"),
+                ("partner", "Jamie"),
+                ("context", "tea recommendations in rush"),
+            ],
+        },
+        {
+            "note": "Noted supply delay email from warehouse indicating delivery truck ETA pushed to Thursday morning.",
+            "entities": [
+                ("focus", "logistics update"),
+                ("change", "delivery now Thursday AM"),
+                ("action_items", "monitor arrival"),
+            ],
+        },
+        {
+            "note": "Documented lobby playlist feedback requesting more acoustic sets in afternoon rotation.",
+            "entities": [
+                ("focus", "ambience feedback"),
+                ("request", "acoustic sets in afternoon"),
+                ("next_steps", "adjust playlist schedule"),
+            ],
+        },
+        {
+            "note": "Logged observation that pastry case lighting flickers intermittently during evening storms.",
+            "entities": [
+                ("focus", "equipment observation"),
+                ("issue", "pastry case lighting flicker"),
+                ("conditions", "evening storms"),
+            ],
+        },
+    ],
+}
+
+base_examples = []
+for category, entries in category_examples.items():
+    for entry in entries:
+        summary = format_summary(category, entry["entities"])
+        for variant in augment_note_variations(entry["note"], max_variants=3):
+            base_examples.append({"note": variant, "summary": summary})
+
+print(f"Constructed {len(base_examples)} augmented examples across {len(NOTE_TYPES)} categories.")
+
+raw_dataset = Dataset.from_list(base_examples)
+split_dataset = raw_dataset.train_test_split(test_size=0.2, seed=SEED, shuffle=True)
+train_dataset = split_dataset["train"]
+validation_dataset = split_dataset["test"]
+
+PROMPT_TEMPLATE = (
+    "You are a Starbucks knowledge assistant. "
+    "Classify the partner note into one of these categories: "
+    + ", ".join(NOTE_TYPES)
+    + ". Summarize key facts as 'CATEGORY | key: value; key: value' with the category first and concise entities. "
+    "Return only the structured summary.\n\nNote: "
+)
 
 def preprocess_examples(batch):
-    inputs = [PROMPT + note for note in batch["note"]]
+    inputs = [PROMPT_TEMPLATE + note for note in batch["note"]]
     tokenized = tokenizer(
         inputs,
         max_length=MAX_SRC_LEN,
@@ -81,25 +648,126 @@ def preprocess_examples(batch):
     tokenized["labels"] = labels
     return tokenized
 
-tokenized_dataset = raw_dataset.map(
+tokenized_train = train_dataset.map(
     preprocess_examples,
     batched=True,
-    remove_columns=raw_dataset.column_names,
+    remove_columns=train_dataset.column_names,
 )
 
-BATCH_SIZE = 2
-EPOCHS = 25
-train_tf_dataset = tokenized_dataset.to_tf_dataset(
+tokenized_validation = validation_dataset.map(
+    preprocess_examples,
+    batched=True,
+    remove_columns=validation_dataset.column_names,
+)
+
+BATCH_SIZE = 1
+EPOCHS = 12
+
+train_tf_dataset = tokenized_train.to_tf_dataset(
     columns=["input_ids", "attention_mask"],
     label_cols=["labels"],
     shuffle=True,
     batch_size=BATCH_SIZE,
 )
 
-optimizer = tf.keras.optimizers.Adam(learning_rate=3e-4)
+validation_tf_dataset = tokenized_validation.to_tf_dataset(
+    columns=["input_ids", "attention_mask"],
+    label_cols=["labels"],
+    shuffle=False,
+    batch_size=BATCH_SIZE,
+)
+
+class MaskedSparseCategoricalAccuracy(tf.keras.metrics.Metric):
+    def __init__(self, name="masked_accuracy", **kwargs):
+        super().__init__(name=name, **kwargs)
+        self.total = self.add_weight(name="total", initializer="zeros")
+        self.count = self.add_weight(name="count", initializer="zeros")
+
+    def update_state(self, y_true, y_pred, sample_weight=None):
+        mask = tf.not_equal(y_true, -100)
+        y_true_masked = tf.boolean_mask(y_true, mask)
+        y_pred_masked = tf.boolean_mask(y_pred, mask)
+        if tf.size(y_true_masked) == 0:
+            return
+        y_pred_ids = tf.cast(tf.argmax(y_pred_masked, axis=-1), tf.int32)
+        matches = tf.cast(tf.equal(y_true_masked, y_pred_ids), tf.float32)
+        self.total.assign_add(tf.reduce_sum(matches))
+        self.count.assign_add(tf.cast(tf.size(matches), tf.float32))
+
+    def result(self):
+        return tf.math.divide_no_nan(self.total, self.count)
+
+    def reset_states(self):
+        self.total.assign(0.0)
+        self.count.assign(0.0)
+
+optimizer = tf.keras.optimizers.Adam(learning_rate=5e-5)
 base_model.trainable = True
-base_model.compile(optimizer=optimizer, run_eagerly=True)
-base_model.fit(train_tf_dataset, epochs=EPOCHS)
+base_model.compile(
+    optimizer=optimizer,
+    loss=base_model.compute_loss,
+    metrics=[MaskedSparseCategoricalAccuracy()],
+    run_eagerly=True,
+)
+
+callbacks = [
+    tf.keras.callbacks.EarlyStopping(monitor="val_loss", patience=2, restore_best_weights=True),
+]
+
+history = base_model.fit(
+    train_tf_dataset,
+    validation_data=validation_tf_dataset,
+    epochs=EPOCHS,
+    callbacks=callbacks,
+)
+
+eval_results = base_model.evaluate(validation_tf_dataset, return_dict=True)
+print("Validation metrics:", eval_results)
+
+def extract_category(text):
+    if "|" in text:
+        prefix = text.split("|")[0]
+    else:
+        prefix = text
+    return prefix.replace(":", "").strip().upper()
+
+validation_records = [validation_dataset[i] for i in range(len(validation_dataset))]
+generated_summaries = []
+for record in validation_records:
+    encoded = tokenizer(
+        PROMPT_TEMPLATE + record["note"],
+        return_tensors="tf",
+        max_length=MAX_SRC_LEN,
+        truncation=True,
+        padding="max_length",
+    )
+    output_ids = base_model.generate(
+        **encoded,
+        max_new_tokens=MAX_TGT_LEN,
+        num_beams=4,
+        length_penalty=0.9,
+        early_stopping=True,
+    )
+    decoded = tokenizer.decode(output_ids[0], skip_special_tokens=True)
+    generated_summaries.append(decoded)
+
+exact_matches = 0
+category_matches = 0
+for prediction, reference in zip(generated_summaries, validation_dataset["summary"]):
+    if prediction.strip() == reference.strip():
+        exact_matches += 1
+    if extract_category(prediction) == extract_category(reference):
+        category_matches += 1
+
+total_eval = len(generated_summaries)
+print("Structured evaluation:")
+print(f"  Samples evaluated: {total_eval}")
+print(f"  Exact match rate: {exact_matches / total_eval:.3f}")
+print(f"  Category accuracy: {category_matches / total_eval:.3f}")
+if generated_summaries:
+    print("  Sample prediction vs reference:")
+    print("   ↳", generated_summaries[0])
+    print("   ↳", validation_dataset["summary"][0])
 
 base_model.save_pretrained(FINETUNED_DIR)
 tokenizer.save_pretrained(FINETUNED_DIR, legacy_format=False)


### PR DESCRIPTION
## Summary
- expand the Starbucks note dataset to 100+ augmented examples that cover all 15 taxonomy categories
- upgrade the prompt, hyperparameters, and batching strategy for improved fine-tuning stability
- add validation split handling, custom masked accuracy tracking, and structured evaluation reporting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfc9859cb883208e0265e353838300