### PR TITLE
Ensure decoder inputs provided for TF T5 training

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -643,9 +643,11 @@ def preprocess_examples(batch):
         truncation=True,
         padding="max_length",
     )
-    labels = np.array(targets["input_ids"], dtype=np.int32)
+    decoder_input_ids = np.array(targets["input_ids"], dtype=np.int32)
+    labels = decoder_input_ids.copy()
     labels[labels == tokenizer.pad_token_id] = -100
     tokenized["labels"] = labels
+    tokenized["decoder_input_ids"] = decoder_input_ids
     return tokenized
 
 tokenized_train = train_dataset.map(
@@ -664,15 +666,13 @@ BATCH_SIZE = 1
 EPOCHS = 12
 
 train_tf_dataset = tokenized_train.to_tf_dataset(
-    columns=["input_ids", "attention_mask"],
-    label_cols=["labels"],
+    columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
     shuffle=True,
     batch_size=BATCH_SIZE,
 )
 
 validation_tf_dataset = tokenized_validation.to_tf_dataset(
-    columns=["input_ids", "attention_mask"],
-    label_cols=["labels"],
+    columns=["input_ids", "attention_mask", "decoder_input_ids", "labels"],
     shuffle=False,
     batch_size=BATCH_SIZE,
 )
@@ -705,8 +705,7 @@ optimizer = tf.keras.optimizers.Adam(learning_rate=5e-5)
 base_model.trainable = True
 base_model.compile(
     optimizer=optimizer,
-    loss=base_model.compute_loss,
-    metrics=[MaskedSparseCategoricalAccuracy()],
+    loss=base_model.hf_compute_loss,
     run_eagerly=True,
 )
 


### PR DESCRIPTION
## Summary
- add decoder input ids to the preprocessing output so the T5 decoder can run during TensorFlow fine-tuning
- include decoder inputs and labels in the tf.data pipeline and compile the model with the HF loss helper to keep training working without custom metrics

## Testing
- not run (fine-tuning takes several minutes on CPU)

------
https://chatgpt.com/codex/tasks/task_e_68dfcc1d31648320aa68961bb2273c82