### PR TITLE
Add callbacks to guard against overfitting during training

### DIFF
--- a/build_tensor.ipynb
+++ b/build_tensor.ipynb
@@ -26,6 +26,8 @@ FINETUNED_DIR = "flan_t5_small_type_first_finetuned"
 OUT_DIR  = "flan_t5_small_type_first_tflite_min"
 ENC_SAVED = os.path.join(OUT_DIR, "encoder_saved_model")
 DEC_SAVED = os.path.join(OUT_DIR, "decoder_step_saved_model")
+BEST_WEIGHTS_PATH = os.path.join(FINETUNED_DIR, "best_epoch.weights.h5")
+os.makedirs(FINETUNED_DIR, exist_ok=True)
 os.makedirs(OUT_DIR, exist_ok=True)
 
 print("TF:", tf.__version__)
@@ -709,9 +711,21 @@ base_model.compile(
     run_eagerly=True,
 )
 
-callbacks = [
-    tf.keras.callbacks.EarlyStopping(monitor="val_loss", patience=2, restore_best_weights=True),
-]
+checkpoint_cb = tf.keras.callbacks.ModelCheckpoint(
+    BEST_WEIGHTS_PATH,
+    monitor="val_loss",
+    save_best_only=True,
+    save_weights_only=True,
+)
+
+early_stop_cb = tf.keras.callbacks.EarlyStopping(
+    monitor="val_loss",
+    patience=3,
+    min_delta=1e-4,
+    restore_best_weights=True,
+)
+
+callbacks = [checkpoint_cb, early_stop_cb]
 
 history = base_model.fit(
     train_tf_dataset,
@@ -719,6 +733,9 @@ history = base_model.fit(
     epochs=EPOCHS,
     callbacks=callbacks,
 )
+
+if os.path.exists(BEST_WEIGHTS_PATH):
+    base_model.load_weights(BEST_WEIGHTS_PATH)
 
 eval_results = base_model.evaluate(validation_tf_dataset, return_dict=True)
 print("Validation metrics:", eval_results)


### PR DESCRIPTION
## Summary
- add a best-weight checkpoint path for the fine-tuned model
- use ModelCheckpoint and EarlyStopping callbacks to capture the best epoch while preventing overfitting
- reload the best weights before evaluation and export

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfd54db33c8320b6db6834ce4ef90b