### PR TITLE
Fix settings PIN change layout overflow

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -4,6 +4,8 @@ import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -238,6 +240,8 @@ fun SettingsScreen(
         )
     }
 
+    val scrollState = rememberScrollState()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -258,6 +262,7 @@ fun SettingsScreen(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
+                .verticalScroll(scrollState)
                 .padding(16.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {


### PR DESCRIPTION
## Summary
- add a scroll state to the settings screen so content can extend beyond the initial viewport
- ensure the PIN change fields and buttons remain accessible by allowing vertical scrolling

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e23f5c16288320ad4af5107c910d51