### PR TITLE
Fix summarizer prompt reuse and regex literals

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -252,9 +252,9 @@ class Summarizer(
                 return@withContext fallback("models unavailable")
             }
 
-            val (_, classifierPrompt) = ensureClassifierDetails()
-            val promptPrefix = if (classifierPrompt.isNotBlank()) {
-                "summarize the note type and structure: $classifierPrompt\n\nNote: "
+            val (_, classifierSummary) = ensureClassifierDetails()
+            val promptPrefix = if (classifierSummary.isNotBlank()) {
+                "summarize the note type and structure: $classifierSummary\n\nNote: "
             } else {
                 "summarize the note type and structure.\n\nNote: "
             }
@@ -713,7 +713,7 @@ class Summarizer(
     private fun sanitizeHighlightCandidate(value: String?): String {
         if (value.isNullOrBlank()) return ""
         val firstLine = value.lineSequence().firstOrNull { it.trim().isNotEmpty() }?.trim() ?: return ""
-        val normalized = firstLine.replace("\s+".toRegex(), " ")
+        val normalized = firstLine.replace("""\s+""".toRegex(), " ")
         return trimToWordLimit(normalized.trimEnd('.', ';', ':'), 16)
     }
 
@@ -785,7 +785,7 @@ class Summarizer(
 
     private fun enforceTwoLineLimit(text: String): String {
         if (text.isBlank()) return text.trim()
-        return text.replace("\s+".toRegex(), " ").trim()
+        return text.replace("""\s+""".toRegex(), " ").trim()
     }
 
     private fun pluralize(noun: String, count: Int): String {


### PR DESCRIPTION
## Summary
- rename the reused classifier prompt destructuring variable to avoid duplicate declarations in the summarizer workflow
- convert whitespace-matching regular expressions to use raw string literals so they compile correctly

## Testing
- ./gradlew :app:compileDebugKotlin --no-configuration-cache --console=plain *(fails: requires Android NDK in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e2496321bc8320b7845f67afc6280e