### PR TITLE
Improve URL completion detection for previews

### DIFF
--- a/app/src/test/java/com/example/starbucknotetaker/LinkPreviewFetcherTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/LinkPreviewFetcherTest.kt
@@ -1,0 +1,33 @@
+package com.example.starbucknotetaker
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinkPreviewFetcherTest {
+
+    @Test
+    fun extractUrls_marksTerminalUrlComplete_whenLooksComplete() {
+        val detections = extractUrls("https://example.com")
+
+        assertEquals(1, detections.size)
+        assertTrue(detections[0].isComplete)
+    }
+
+    @Test
+    fun extractUrls_doesNotPrematurelyCompletePartialUrl() {
+        val detections = extractUrls("https://example")
+
+        assertEquals(1, detections.size)
+        assertFalse(detections[0].isComplete)
+    }
+
+    @Test
+    fun extractUrls_marksLocalhostWithPortComplete() {
+        val detections = extractUrls("Visit http://localhost:3000")
+
+        assertEquals(1, detections.size)
+        assertTrue(detections[0].isComplete)
+    }
+}


### PR DESCRIPTION
## Summary
- mark URLs that appear complete as ready for preview even without trailing whitespace
- add heuristics covering localhost, IPs, ports, and query fragments when checking URL completeness
- add unit tests for URL extraction completeness detection

## Testing
- ./gradlew test --console=plain *(fails: NDK is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e249c72dc083208ba87852dcea32e9