### PR TITLE
Fix summarizer classifier naming conflict and configuration cache access

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -258,9 +258,9 @@ tasks.matching { it.name.startsWith('merge') && it.name.endsWith('NativeLibs') }
 
 tasks.withType(MergeNativeLibsTask).configureEach { task ->
     task.notCompatibleWithConfigurationCache('Aligns native libraries using an external script')
-    doLast {
+    def gradleProject = task.project
+    task.doLast {
         def outputDir = task.outputDir.get().asFile
-        def gradleProject = project
         def alignedLibraries = gradleProject.fileTree(dir: outputDir, include: ['**/*.so']).files
         alignNativeLibrariesAction(gradleProject, alignedLibraries)
     }

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -176,7 +176,7 @@ class Summarizer(
         try {
             emitDebug("summarizing text of length ${text.length}")
             var classifierLabel: NoteNatureLabel? = null
-            var classifierSummary: String? = null
+            var classifierSummaryHint: String? = null
             var fallbackLabelLogged = false
             val classifierInstance = ensureClassifier()
             if (classifierInstance != null) {
@@ -188,7 +188,7 @@ class Summarizer(
                     )
                     if (label.humanReadable.isNotBlank()) {
                         val trimmed = trimToWordLimit(label.humanReadable, CLASSIFIER_WORD_LIMIT)
-                        classifierSummary = trimmed
+                        classifierSummaryHint = trimmed
                         emitDebug("classifier summary output: $trimmed")
                         if (label.confidence > 0.0) {
                             _state.emit(SummarizerState.Ready)
@@ -214,8 +214,9 @@ class Summarizer(
                     classifierLabel = it
                     fallbackLabelLogged = true
                 }
-                val summary = classifierSummary ?: trimToWordLimit(label.humanReadable, CLASSIFIER_WORD_LIMIT)
-                    .also { classifierSummary = it }
+                val summary = classifierSummaryHint
+                    ?: trimToWordLimit(label.humanReadable, CLASSIFIER_WORD_LIMIT)
+                        .also { classifierSummaryHint = it }
                 return label to summary
             }
 
@@ -252,9 +253,9 @@ class Summarizer(
                 return@withContext fallback("models unavailable")
             }
 
-            val (_, classifierSummary) = ensureClassifierDetails()
-            val promptPrefix = if (classifierSummary.isNotBlank()) {
-                "summarize the note type and structure: $classifierSummary\n\nNote: "
+            val (_, classifierSummaryHintValue) = ensureClassifierDetails()
+            val promptPrefix = if (classifierSummaryHintValue.isNotBlank()) {
+                "summarize the note type and structure: $classifierSummaryHintValue\n\nNote: "
             } else {
                 "summarize the note type and structure.\n\nNote: "
             }


### PR DESCRIPTION
## Summary
- rename the summarizer's classifier summary cache to avoid conflicting declarations during Kotlin compilation
- capture the project reference when configuring native library alignment to keep the task compatible with the configuration cache

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain *(fails: Installed Build Tools revision 34.0.0 is corrupted in the build environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e24f8e0aac8320b653999cb4825243