### PR TITLE
Fix all-day event end date display

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -664,13 +664,12 @@ private fun buildEventSummary(
         appendLine("Event details:")
         if (event.allDay) {
             val startDate = start.toLocalDate()
-            val endDateExclusive = end.toLocalDate()
-            val lastDate = endDateExclusive.minusDays(1)
-            if (lastDate.isBefore(startDate) || lastDate.isEqual(startDate)) {
+            val endDateInclusive = end.toLocalDate()
+            if (endDateInclusive.isBefore(startDate) || endDateInclusive.isEqual(startDate)) {
                 appendLine("All-day on ${detailDateFormatter.format(start)} ($zoneCode)")
             } else {
                 appendLine(
-                    "All-day from ${detailDateFormatter.format(start)} to ${detailDateFormatter.format(lastDate)} ($zoneCode)"
+                    "All-day from ${detailDateFormatter.format(start)} to ${detailDateFormatter.format(endDateInclusive)} ($zoneCode)"
                 )
             }
         } else {
@@ -769,13 +768,12 @@ private fun EventDetailsCard(
             Spacer(modifier = Modifier.height(8.dp))
             if (event.allDay) {
                 val startDate = start.toLocalDate()
-                val endDateExclusive = end.toLocalDate()
-                val lastDate = endDateExclusive.minusDays(1)
-                if (lastDate.isBefore(startDate) || lastDate.isEqual(startDate)) {
+                val endDateInclusive = end.toLocalDate()
+                if (endDateInclusive.isBefore(startDate) || endDateInclusive.isEqual(startDate)) {
                     Text("All-day on ${detailDateFormatter.format(start)} ($zoneCode)")
                 } else {
                     Text(
-                        "All-day from ${detailDateFormatter.format(start)} to ${detailDateFormatter.format(lastDate)} ($zoneCode)"
+                        "All-day from ${detailDateFormatter.format(start)} to ${detailDateFormatter.format(endDateInclusive)} ($zoneCode)"
                     )
                 }
             } else {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -431,12 +431,11 @@ private fun formatEventRange(event: NoteEvent): String {
     val zoneCode = formatZoneCode(zoneId, Locale.getDefault(), start.toInstant())
     return if (event.allDay) {
         val startDate = start.toLocalDate()
-        val endDateExclusive = end.toLocalDate()
-        val lastDate = endDateExclusive.minusDays(1)
-        if (lastDate.isBefore(startDate) || lastDate.isEqual(startDate)) {
+        val endDateInclusive = end.toLocalDate()
+        if (endDateInclusive.isBefore(startDate) || endDateInclusive.isEqual(startDate)) {
             "All-day • $zoneCode"
         } else {
-            "All-day • Ends ${eventDayFormatter.format(lastDate)} • $zoneCode"
+            "All-day • Ends ${eventDayFormatter.format(endDateInclusive)} • $zoneCode"
         }
     } else {
         val sameDay = start.toLocalDate() == end.toLocalDate()


### PR DESCRIPTION
## Summary
- treat stored all-day event end timestamps as inclusive when building summaries
- update the note list and detail screens to show the selected final day instead of the prior day

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3090d893883209cb148d7ac3354fc