### PR TITLE
Add sketch pad support for note attachments

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NewNoteImage.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NewNoteImage.kt
@@ -1,0 +1,15 @@
+package com.example.starbucknotetaker
+
+import android.net.Uri
+
+/**
+ * Represents an image selected while creating a note. Images can originate from
+ * an external URI or be generated in-app (e.g. a sketch), which is delivered as
+ * a base64 encoded PNG via [data]. Any rotation requested by the user is stored
+ * in [rotation] so it can be applied when persisting the image.
+ */
+data class NewNoteImage(
+    val uri: Uri? = null,
+    val rotation: Int = 0,
+    val data: String? = null,
+)

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.RotateLeft
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Image
 import androidx.compose.material.icons.filled.InsertDriveFile
 import androidx.compose.material.icons.filled.Mic
@@ -454,6 +455,7 @@ fun EditNoteScreen(
     }
 
     var showTranscriptionDialog by remember { mutableStateOf(false) }
+    var showSketchPad by remember { mutableStateOf(false) }
     val recordAudioPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
@@ -1082,6 +1084,13 @@ fun EditNoteScreen(
                         )
                     }
                     AttachmentAction(
+                        icon = Icons.Default.Edit,
+                        label = "Sketch",
+                    ) {
+                        onDisablePinCheck()
+                        showSketchPad = true
+                    }
+                    AttachmentAction(
                         icon = Icons.Default.Mic,
                         label = "Transcribe",
                     ) {
@@ -1108,6 +1117,28 @@ fun EditNoteScreen(
                 }
             }
         }
+    }
+
+    if (showSketchPad) {
+        SketchPadDialog(
+            onDismiss = {
+                showSketchPad = false
+                onEnablePinCheck()
+            },
+            onSave = { bytes ->
+                val encoded = Base64.encodeToString(bytes, Base64.DEFAULT)
+                val last = blocks.lastOrNull()
+                if (last is EditBlock.Text && last.value.text.isBlank()) {
+                    blocks[blocks.size - 1] = EditBlock.Image(null, encoded)
+                    blocks.add(EditBlock.Text(RichTextValue.fromPlainText("")))
+                } else {
+                    blocks.add(EditBlock.Image(null, encoded))
+                    blocks.add(EditBlock.Text(RichTextValue.fromPlainText("")))
+                }
+                showSketchPad = false
+                onEnablePinCheck()
+            }
+        )
     }
 
     if (showTranscriptionDialog) {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
@@ -1,0 +1,203 @@
+package com.example.starbucknotetaker.ui
+
+import android.graphics.Bitmap
+import android.graphics.Canvas as AndroidCanvas
+import android.graphics.Color as AndroidColor
+import android.graphics.Paint
+import android.graphics.Path
+import java.io.ByteArrayOutputStream
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.Stroke
+import androidx.compose.ui.graphics.drawscope.drawPath
+import androidx.compose.ui.input.pointer.awaitEachGesture
+import androidx.compose.ui.input.pointer.awaitFirstDown
+import androidx.compose.ui.input.pointer.awaitPointerEvent
+import androidx.compose.ui.input.pointer.consume
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import kotlin.math.roundToInt
+
+@Composable
+fun SketchPadDialog(
+    onDismiss: () -> Unit,
+    onSave: (ByteArray) -> Unit,
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(
+            shape = RoundedCornerShape(12.dp),
+            color = MaterialTheme.colors.surface,
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Text(
+                    text = "Sketch",
+                    style = MaterialTheme.typography.h6,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                val strokes = remember { mutableStateListOf<List<Offset>>() }
+                var activeStroke by remember { mutableStateOf<List<Offset>>(emptyList()) }
+                var canvasSize by remember { mutableStateOf(IntSize.Zero) }
+                val strokeWidthPx = with(LocalDensity.current) { 4.dp.toPx() }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(300.dp)
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.White)
+                        .border(1.dp, MaterialTheme.colors.onSurface.copy(alpha = 0.12f), RoundedCornerShape(8.dp))
+                ) {
+                    Canvas(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(300.dp)
+                            .pointerInput(Unit) {
+                                awaitEachGesture {
+                                    val stroke = mutableListOf<Offset>()
+                                    val down = awaitFirstDown()
+                                    stroke.add(down.position)
+                                    activeStroke = stroke.toList()
+                                    down.consume()
+                                    while (true) {
+                                        val event = awaitPointerEvent()
+                                        val change = event.changes.firstOrNull() ?: break
+                                        if (change.pressed) {
+                                            stroke.add(change.position)
+                                            activeStroke = stroke.toList()
+                                            change.consume()
+                                        } else {
+                                            change.consume()
+                                            break
+                                        }
+                                    }
+                                    if (stroke.isNotEmpty()) {
+                                        strokes.add(stroke.toList())
+                                    }
+                                    activeStroke = emptyList()
+                                }
+                            }
+                    ) {
+                        canvasSize = IntSize(size.width.roundToInt(), size.height.roundToInt())
+                        drawRect(Color.White)
+                        val strokeStyle = Stroke(
+                            width = strokeWidthPx,
+                            cap = StrokeCap.Round,
+                            join = StrokeJoin.Round,
+                        )
+                        val allStrokes = strokes + activeStroke.let { if (it.isEmpty()) emptyList() else listOf(it) }
+                        allStrokes.forEach { points ->
+                            if (points.size == 1) {
+                                drawCircle(
+                                    color = Color.Black,
+                                    radius = strokeWidthPx / 2f,
+                                    center = points.first(),
+                                )
+                            } else if (points.size > 1) {
+                                val path = androidx.compose.ui.graphics.Path().apply {
+                                    moveTo(points.first().x, points.first().y)
+                                    points.drop(1).forEach { point ->
+                                        lineTo(point.x, point.y)
+                                    }
+                                }
+                                drawPath(
+                                    path = path,
+                                    color = Color.Black,
+                                    style = strokeStyle,
+                                )
+                            }
+                        }
+                    }
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    OutlinedButton(onClick = {
+                        strokes.clear()
+                        activeStroke = emptyList()
+                    }) {
+                        Text("Clear")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    OutlinedButton(onClick = onDismiss) {
+                        Text("Cancel")
+                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Button(onClick = {
+                        if (canvasSize.width <= 0 || canvasSize.height <= 0 ||
+                            (strokes.isEmpty() && activeStroke.isEmpty())
+                        ) {
+                            onDismiss()
+                            return@Button
+                        }
+                        val bitmap = Bitmap.createBitmap(
+                            canvasSize.width,
+                            canvasSize.height,
+                            Bitmap.Config.ARGB_8888,
+                        )
+                        val canvas = AndroidCanvas(bitmap)
+                        canvas.drawColor(AndroidColor.WHITE)
+                        val paint = Paint().apply {
+                            color = AndroidColor.BLACK
+                            style = Paint.Style.STROKE
+                            strokeJoin = Paint.Join.ROUND
+                            strokeCap = Paint.Cap.ROUND
+                            strokeWidth = strokeWidthPx
+                            isAntiAlias = true
+                        }
+                        val pointsToRender = strokes + activeStroke.let { if (it.isEmpty()) emptyList() else listOf(it) }
+                        pointsToRender.forEach { points ->
+                            if (points.size == 1) {
+                                canvas.drawPoint(points.first().x, points.first().y, paint)
+                            } else if (points.size > 1) {
+                                val path = Path().apply {
+                                    moveTo(points.first().x, points.first().y)
+                                    points.drop(1).forEach { point ->
+                                        lineTo(point.x, point.y)
+                                    }
+                                }
+                                canvas.drawPath(path, paint)
+                            }
+                        }
+                        val output = ByteArrayOutputStream()
+                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+                        onSave(output.toByteArray())
+                    }) {
+                        Text("Save")
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable SketchPadDialog composable for capturing sketches as PNG byte arrays
- integrate the sketch pad into add/edit note flows and carry generated images with the new NewNoteImage model
- update NoteViewModel image processing to handle Base64 sketches and persist them through the existing storage pipeline

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: NDK is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e31820dde48320a6cf5d09c60dc469