### PR TITLE
Adjust swipe delete action height to match note items

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -222,22 +222,21 @@ private fun SwipeToDeleteNoteItem(
     ) {
         Box(
             modifier = Modifier
+                .align(Alignment.CenterEnd)
                 .fillMaxHeight()
                 .width(actionWidth)
-                .align(Alignment.CenterEnd)
-                .background(Color.Red),
-            contentAlignment = Alignment.Center
+                .background(Color.Red)
+                .clickable {
+                    onDelete()
+                    scope.launch { swipeState.snapTo(0) }
+                }
         ) {
-            IconButton(onClick = {
-                onDelete()
-                scope.launch { swipeState.snapTo(0) }
-            }) {
-                Icon(
-                    Icons.Default.Delete,
-                    contentDescription = "Delete",
-                    tint = Color.White
-                )
-            }
+            Icon(
+                Icons.Default.Delete,
+                contentDescription = "Delete",
+                tint = Color.White,
+                modifier = Modifier.align(Alignment.Center)
+            )
         }
         NoteListItem(
             note = note,


### PR DESCRIPTION
## Summary
- ensure the swipe-to-delete action fills the full height of note list entries

## Testing
- not run (not feasible in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e32e84de0883208c8addfd986f4f07