### PR TITLE
Improve audio permission handling in transcription dialog

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -1010,6 +1010,11 @@ fun AddNoteScreen(
             },
             onResult = { result ->
                 appendTranscribedText(result)
+            },
+            onRequireAudioPermission = {
+                showTranscriptionDialog = false
+                onEnablePinCheck()
+                recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
             }
         )
     }

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -1176,6 +1176,11 @@ fun EditNoteScreen(
             },
             onResult = { result ->
                 appendTranscribedText(result)
+            },
+            onRequireAudioPermission = {
+                showTranscriptionDialog = false
+                onEnablePinCheck()
+                recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
             }
         )
     }


### PR DESCRIPTION
## Summary
- add an optional permission callback to `AudioTranscriptionDialog` and surface an inline recovery action
- trigger the callback when microphone permissions are missing so hosts can re-launch the permission flow
- update add/edit screens to re-request audio permissions consistently when transcription fails

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e32ea903608320beab2f2f6f60d3d4