### PR TITLE
Ensure edit screens scroll with keyboard

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -515,7 +515,8 @@ fun AddNoteScreen(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
-                .imePadding(),
+                .imePadding()
+                .imeNestedScroll(),
             contentPadding = PaddingValues(
                 start = 16.dp,
                 end = 16.dp,

--- a/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/EditNoteScreen.kt
@@ -635,7 +635,8 @@ fun EditNoteScreen(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
-                .imePadding(),
+                .imePadding()
+                .imeNestedScroll(),
             contentPadding = PaddingValues(
                 start = 16.dp,
                 end = 16.dp,


### PR DESCRIPTION
## Summary
- enable IME-aware nested scrolling on the add and edit note screens
- allow long content sections to be fully scrolled above the on-screen keyboard

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e33056ba0083208d870d80ca9a4f5a