### PR TITLE
Handle permanently denied microphone permission

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AddNoteScreen.kt
@@ -1,10 +1,13 @@
 package com.example.starbucknotetaker.ui
 
 import android.Manifest
+import android.app.Activity
 import android.app.DatePickerDialog
 import android.app.TimePickerDialog
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.BitmapFactory
 import android.net.Uri
 import android.os.Build
@@ -56,6 +59,7 @@ import com.example.starbucknotetaker.extractUrls
 import com.example.starbucknotetaker.PendingShare
 import com.example.starbucknotetaker.R
 import androidx.core.content.ContextCompat
+import androidx.core.app.ActivityCompat
 import com.example.starbucknotetaker.NewNoteImage
 import com.example.starbucknotetaker.richtext.RichTextDocument
 import com.example.starbucknotetaker.richtext.RichTextDocumentBuilder
@@ -365,17 +369,29 @@ fun AddNoteScreen(
 
     var showTranscriptionDialog by remember { mutableStateOf(false) }
     var showSketchPad by remember { mutableStateOf(false) }
+    var showAudioPermissionSettingsDialog by remember { mutableStateOf(false) }
     val recordAudioPermissionLauncher = rememberLauncherForActivityResult(
         ActivityResultContracts.RequestPermission()
     ) { granted ->
         if (granted) {
             showTranscriptionDialog = true
         } else {
-            Toast.makeText(
-                context,
-                "Microphone permission is required to transcribe audio",
-                Toast.LENGTH_LONG
-            ).show()
+            val activity = context.findActivity()
+            val shouldShowRationale = activity?.let {
+                ActivityCompat.shouldShowRequestPermissionRationale(
+                    it,
+                    Manifest.permission.RECORD_AUDIO
+                )
+            } ?: true
+            if (!shouldShowRationale) {
+                showAudioPermissionSettingsDialog = true
+            } else {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.microphone_permission_toast),
+                    Toast.LENGTH_LONG
+                ).show()
+            }
             onEnablePinCheck()
         }
     }
@@ -1015,7 +1031,34 @@ fun AddNoteScreen(
             onRequireAudioPermission = {
                 showTranscriptionDialog = false
                 onEnablePinCheck()
-                recordAudioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+                showAudioPermissionSettingsDialog = true
+            }
+        )
+    }
+
+    if (showAudioPermissionSettingsDialog) {
+        AlertDialog(
+            onDismissRequest = { showAudioPermissionSettingsDialog = false },
+            title = { Text(stringResource(R.string.microphone_permission_required_title)) },
+            text = { Text(stringResource(R.string.microphone_permission_required_message)) },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        showAudioPermissionSettingsDialog = false
+                        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                            data = Uri.fromParts("package", context.packageName, null)
+                            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        }
+                        context.startActivity(intent)
+                    }
+                ) {
+                    Text(stringResource(R.string.microphone_permission_settings_action))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showAudioPermissionSettingsDialog = false }) {
+                    Text(stringResource(R.string.microphone_permission_settings_dismiss))
+                }
             }
         )
     }
@@ -1043,6 +1086,12 @@ private sealed class NoteBlock {
         val lastFetchedUrl: String? = null,
         override val id: Long = nextNoteBlockId(),
     ) : NoteBlock()
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }
 
 @Composable

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -22,6 +22,11 @@
     <string name="reminder_exact_alarm_permission_denied">Exact alarms are still disabled. Alarm reminders will arrive as notifications.</string>
     <string name="reminder_exact_alarm_permission_needed">Allow exact alarms to enable full-screen alarms.</string>
     <string name="reminder_exact_alarm_permission_action">Open alarm settings</string>
+    <string name="microphone_permission_required_title">Microphone access required</string>
+    <string name="microphone_permission_required_message">Starbuck Notes needs microphone access to transcribe audio. Enable the permission in Settings &gt; Apps &gt; Starbuck Notes &gt; Permissions.</string>
+    <string name="microphone_permission_settings_action">Open app settings</string>
+    <string name="microphone_permission_settings_dismiss">Not now</string>
+    <string name="microphone_permission_toast">Microphone access is required to transcribe audio. Please allow it in app settings.</string>
     <string name="event_alarm_toggle_label">Alarm</string>
     <string name="event_reminder_toggle_label">Reminder</string>
     <string name="event_alarm_lead_time_label">Alarm lead time</string>


### PR DESCRIPTION
## Summary
- detect when the RECORD_AUDIO permission is permanently denied on add and edit note screens
- show a dialog explaining why microphone access is needed and route users to the app settings screen
- centralize the permission messaging strings for reuse across the UI

## Testing
- ./gradlew --no-daemon --console=plain :app:compileDebugKotlin *(fails: NDK is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3333ace3483208c2adfd9840bc9a3