### PR TITLE
Add clear search icon to note list filter

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.filled.Event
 import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ViewList
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Alignment
@@ -145,6 +146,22 @@ fun NoteListScreen(
                 value = query,
                 onValueChange = { query = it },
                 label = { Text("Search") },
+                trailingIcon = {
+                    if (query.isNotBlank()) {
+                        IconButton(
+                            onClick = {
+                                query = ""
+                                focusManager.clearFocus(force = true)
+                                hideKeyboard()
+                            }
+                        ) {
+                            Icon(
+                                imageVector = Icons.Default.Close,
+                                contentDescription = "Clear search"
+                            )
+                        }
+                    }
+                },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(8.dp)


### PR DESCRIPTION
## Summary
- add a trailing clear icon to the note list search field
- reset focus and hide the keyboard when the search is cleared

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e337cb2c308320ab95957c08103292