### PR TITLE
Adjust note list padding for FAB

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -166,12 +166,13 @@ fun NoteListScreen(
                     .fillMaxWidth()
                     .padding(8.dp)
             )
+            val fabVerticalSpace = 56.dp + 16.dp
             val contentModifier = Modifier
                 .fillMaxSize()
                 .padding(horizontal = 8.dp)
             if (filtered.isEmpty()) {
                 Column(
-                    modifier = contentModifier,
+                    modifier = contentModifier.padding(bottom = fabVerticalSpace),
                     verticalArrangement = Arrangement.Center,
                     horizontalAlignment = Alignment.CenterHorizontally
                 ) {
@@ -207,7 +208,10 @@ fun NoteListScreen(
                     }
                 }
             } else {
-                LazyColumn(modifier = contentModifier) {
+                LazyColumn(
+                    modifier = contentModifier,
+                    contentPadding = PaddingValues(bottom = fabVerticalSpace)
+                ) {
                     itemsIndexed(filtered, key = { _, note -> note.id }) { index, note ->
                         val showDate = index == 0 || !isSameDay(filtered[index - 1].date, note.date)
                         if (showDate) {


### PR DESCRIPTION
## Summary
- add bottom padding constant that matches the floating action button height plus margin
- apply the padding to the note list and empty state so content is not obscured by the FABs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3398a85248320b4be4cf646214129