### PR TITLE
Add undo support to note deletion

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -388,7 +388,7 @@ fun AppContent(
                 onOpenNote = { note ->
                     val isTemporarilyUnlocked = noteViewModel.isNoteTemporarilyUnlocked(note.id)
                     Log.d(BIOMETRIC_LOG_TAG, "*** NOTE_TAP: noteId=${note.id} locked=${note.isLocked} temporarilyUnlocked=$isTemporarilyUnlocked ***")
-                    
+
                     if (note.isLocked && !isTemporarilyUnlocked) {
                         if (canUseBiometric) {
                             Log.d(BIOMETRIC_LOG_TAG, "*** NOTE_TAP: Starting BiometricUnlockActivity for noteId=${note.id} ***")
@@ -405,6 +405,7 @@ fun AppContent(
                     }
                 },
                 onDeleteNote = { noteId -> noteViewModel.deleteNote(noteId) },
+                onRestoreNote = { note -> noteViewModel.restoreNote(note) },
                 onSettings = { navController.navigate("settings") },
                 summarizerState = summarizerState
             )

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -251,6 +251,17 @@ class NoteViewModel(
         }
     }
 
+    fun restoreNote(note: Note) {
+        if (_notes.any { it.id == note.id }) {
+            return
+        }
+        _notes.add(note)
+        reorderNotes()
+        pin?.let { store?.saveNotes(_notes, it) }
+        reminderScheduler?.scheduleIfNeeded(note)
+        tryEmitPendingReminder()
+    }
+
     fun updateNote(
         id: Long,
         title: String?,


### PR DESCRIPTION
## Summary
- add a scaffold state to the note list screen to support snackbars
- show an undo snackbar when deleting a note and restore it if the action is tapped
- expose a restoreNote helper on the view model and wire it through the activity

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e33b440f8483208207aac184f87f91