### PR TITLE
Adjust audio transcription controls height

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/AudioTranscriptionDialog.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/AudioTranscriptionDialog.kt
@@ -357,7 +357,7 @@ fun AudioTranscriptionDialog(
                 Spacer(modifier = Modifier.weight(1f, fill = true))
 
                 val normalizedLevel = ((rms + 2f) / 10f).coerceIn(0f, 1f)
-                val recordButtonSize = 96.dp * 1.5f
+                val recordButtonSize = 50.dp
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary
- reduce the audio level meter and record button to a consistent 50 dp height on the transcription dialog

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e3494482b48320914d6263fd3234c7