### PR TITLE
Ensure swipe delete action spans full note height

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -288,6 +288,7 @@ private fun SwipeToDeleteNoteItem(
     Box(
         modifier = Modifier
             .fillMaxWidth()
+            .height(IntrinsicSize.Min)
             .background(Color.Transparent)
             .swipeable(
                 state = swipeState,


### PR DESCRIPTION
## Summary
- ensure the swipe-to-delete action container measures to the full height of the note list item by using intrinsic height sizing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e34a0cdb288320acafc967a2f5ba02