### PR TITLE
Add sketch pad drawing controls

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
@@ -9,6 +9,9 @@ import java.io.ByteArrayOutputStream
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,11 +22,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.AlertDialog
 import androidx.compose.material.Button
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.OutlinedButton
+import androidx.compose.material.Slider
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -34,14 +40,33 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import kotlin.math.roundToInt
+
+private data class Stroke(
+    val points: List<Offset>,
+    val color: Color,
+    val strokeWidth: Float,
+)
+
+private data class TextItem(
+    val text: String,
+    val position: Offset,
+    val color: Color,
+)
+
+private sealed class DrawAction {
+    data class StrokeAction(val stroke: Stroke) : DrawAction()
+    data class TextAction(val textItem: TextItem) : DrawAction()
+}
 
 @Composable
 fun SketchPadDialog(
@@ -59,10 +84,27 @@ fun SketchPadDialog(
                     style = MaterialTheme.typography.h6,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
-                val strokes = remember { mutableStateListOf<List<Offset>>() }
-                var activeStroke by remember { mutableStateOf<List<Offset>>(emptyList()) }
+                val strokes = remember { mutableStateListOf<Stroke>() }
+                var activeStroke by remember { mutableStateOf<Stroke?>(null) }
+                val textItems = remember { mutableStateListOf<TextItem>() }
+                val undoStack = remember { mutableStateListOf<DrawAction>() }
+                val redoStack = remember { mutableStateListOf<DrawAction>() }
+                var selectedColor by remember { mutableStateOf(Color.Black) }
+                var strokeWidthDp by remember { mutableStateOf(4f) }
+                var showTextDialog by remember { mutableStateOf(false) }
+                var pendingText by remember { mutableStateOf("") }
+                var isPlacingText by remember { mutableStateOf(false) }
+                val density = LocalDensity.current
+                val strokeWidthPx = with(density) { strokeWidthDp.dp.toPx() }
                 var canvasSize by remember { mutableStateOf(IntSize.Zero) }
-                val strokeWidthPx = with(LocalDensity.current) { 4.dp.toPx() }
+                val colorOptions = listOf(
+                    Color.Black,
+                    Color.Red,
+                    Color.Blue,
+                    Color.Green,
+                    Color.Magenta,
+                    Color(0xFFFFA500),
+                )
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -75,129 +117,325 @@ fun SketchPadDialog(
                         modifier = Modifier
                             .fillMaxWidth()
                             .height(300.dp)
-                            .pointerInput(Unit) {
-                                var currentStroke: MutableList<Offset>? = null
-                                detectDragGestures(
-                                    onDragStart = { offset ->
-                                        val stroke = mutableListOf(offset)
-                                        activeStroke = stroke.toList()
-                                        currentStroke = stroke
-                                    },
-                                    onDragEnd = {
-                                        currentStroke?.let { stroke ->
-                                            if (stroke.isNotEmpty()) {
-                                                strokes.add(stroke.toList())
-                                            }
+                            .pointerInput(isPlacingText, selectedColor, strokeWidthPx) {
+                                if (isPlacingText) {
+                                    detectTapGestures { offset ->
+                                        val text = pendingText.trim()
+                                        if (text.isNotEmpty()) {
+                                            val textItem = TextItem(
+                                                text = text,
+                                                position = offset,
+                                                color = selectedColor,
+                                            )
+                                            textItems.add(textItem)
+                                            undoStack.add(DrawAction.TextAction(textItem))
+                                            redoStack.clear()
                                         }
-                                        currentStroke = null
-                                        activeStroke = emptyList()
-                                    },
-                                    onDragCancel = {
-                                        currentStroke = null
-                                        activeStroke = emptyList()
-                                    },
-                                    onDrag = { change, _ ->
-                                        val stroke = currentStroke ?: mutableListOf<Offset>().also {
-                                            currentStroke = it
-                                        }
-                                        stroke.add(change.position)
-                                        activeStroke = stroke.toList()
+                                        pendingText = ""
+                                        isPlacingText = false
                                     }
-                                )
+                                } else {
+                                    var currentStrokePoints: MutableList<Offset>? = null
+                                    detectDragGestures(
+                                        onDragStart = { offset ->
+                                            val points = mutableListOf(offset)
+                                            val stroke = Stroke(
+                                                points = points.toList(),
+                                                color = selectedColor,
+                                                strokeWidth = strokeWidthPx,
+                                            )
+                                            currentStrokePoints = points
+                                            activeStroke = stroke
+                                        },
+                                        onDragEnd = {
+                                            val strokePoints = currentStrokePoints
+                                            if (strokePoints != null && strokePoints.isNotEmpty()) {
+                                                val stroke = activeStroke
+                                                if (stroke != null) {
+                                                    strokes.add(stroke)
+                                                    undoStack.add(DrawAction.StrokeAction(stroke))
+                                                    redoStack.clear()
+                                                }
+                                            }
+                                            currentStrokePoints = null
+                                            activeStroke = null
+                                        },
+                                        onDragCancel = {
+                                            currentStrokePoints = null
+                                            activeStroke = null
+                                        },
+                                        onDrag = { change, _ ->
+                                            val strokePoints = currentStrokePoints ?: mutableListOf<Offset>().also {
+                                                currentStrokePoints = it
+                                            }
+                                            strokePoints.add(change.position)
+                                            val updatedStroke = Stroke(
+                                                points = strokePoints.toList(),
+                                                color = selectedColor,
+                                                strokeWidth = strokeWidthPx,
+                                            )
+                                            activeStroke = updatedStroke
+                                        }
+                                    )
+                                }
                             }
                     ) {
                         canvasSize = IntSize(size.width.roundToInt(), size.height.roundToInt())
                         drawRect(Color.White)
-                        val allStrokes = strokes + activeStroke.let { if (it.isEmpty()) emptyList() else listOf(it) }
-                        allStrokes.forEach { points ->
+                        val allStrokes = buildList {
+                            addAll(strokes)
+                            activeStroke?.let { add(it) }
+                        }
+                        allStrokes.forEach { stroke ->
+                            val points = stroke.points
                             if (points.size == 1) {
                                 drawCircle(
-                                    color = Color.Black,
-                                    radius = strokeWidthPx / 2f,
+                                    color = stroke.color,
+                                    radius = stroke.strokeWidth / 2f,
                                     center = points.first(),
                                 )
                             } else if (points.size > 1) {
                                 drawCircle(
-                                    color = Color.Black,
-                                    radius = strokeWidthPx / 2f,
+                                    color = stroke.color,
+                                    radius = stroke.strokeWidth / 2f,
                                     center = points.first(),
                                 )
                                 points.zipWithNext().forEach { (start, end) ->
                                     drawLine(
-                                        color = Color.Black,
+                                        color = stroke.color,
                                         start = start,
                                         end = end,
-                                        strokeWidth = strokeWidthPx,
+                                        strokeWidth = stroke.strokeWidth,
                                         cap = StrokeCap.Round,
                                     )
                                 }
                                 drawCircle(
-                                    color = Color.Black,
-                                    radius = strokeWidthPx / 2f,
+                                    color = stroke.color,
+                                    radius = stroke.strokeWidth / 2f,
                                     center = points.last(),
+                                )
+                            }
+                        }
+                        textItems.forEach { textItem ->
+                            drawIntoCanvas { canvas ->
+                                val paint = Paint().apply {
+                                    color = textItem.color.toArgb()
+                                    textSize = with(density) { 16.sp.toPx() }
+                                    isAntiAlias = true
+                                }
+                                canvas.nativeCanvas.drawText(
+                                    textItem.text,
+                                    textItem.position.x,
+                                    textItem.position.y,
+                                    paint,
                                 )
                             }
                         }
                     }
                 }
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(text = "Line colour")
+                Spacer(modifier = Modifier.height(8.dp))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                ) {
+                    colorOptions.forEach { color ->
+                        val isSelected = color == selectedColor
+                        Box(
+                            modifier = Modifier
+                                .width(32.dp)
+                                .height(32.dp)
+                                .clip(RoundedCornerShape(16.dp))
+                                .background(color)
+                                .border(
+                                    width = if (isSelected) 2.dp else 1.dp,
+                                    color = if (isSelected) MaterialTheme.colors.primary else Color.LightGray,
+                                    shape = RoundedCornerShape(16.dp),
+                                )
+                                .clickable { selectedColor = color },
+                        )
+                    }
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Text(text = "Line thickness")
+                Slider(
+                    value = strokeWidthDp,
+                    onValueChange = { strokeWidthDp = it },
+                    valueRange = 1f..20f,
+                )
+                if (isPlacingText) {
+                    Text(
+                        text = "Tap on the sketch to place your text.",
+                        style = MaterialTheme.typography.body2,
+                        color = MaterialTheme.colors.primary,
+                    )
+                }
+                Spacer(modifier = Modifier.height(16.dp))
+                OutlinedButton(onClick = {
+                    pendingText = ""
+                    showTextDialog = true
+                }) {
+                    Text("Add text")
+                }
                 Spacer(modifier = Modifier.height(16.dp))
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End,
+                    horizontalArrangement = Arrangement.SpaceBetween,
                 ) {
-                    OutlinedButton(onClick = {
-                        strokes.clear()
-                        activeStroke = emptyList()
-                    }) {
-                        Text("Clear")
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    OutlinedButton(onClick = onDismiss) {
-                        Text("Cancel")
-                    }
-                    Spacer(modifier = Modifier.width(8.dp))
-                    Button(onClick = {
-                        if (canvasSize.width <= 0 || canvasSize.height <= 0 ||
-                            (strokes.isEmpty() && activeStroke.isEmpty())
-                        ) {
-                            onDismiss()
-                            return@Button
-                        }
-                        val bitmap = Bitmap.createBitmap(
-                            canvasSize.width,
-                            canvasSize.height,
-                            Bitmap.Config.ARGB_8888,
-                        )
-                        val canvas = AndroidCanvas(bitmap)
-                        canvas.drawColor(AndroidColor.WHITE)
-                        val paint = Paint().apply {
-                            color = AndroidColor.BLACK
-                            style = Paint.Style.STROKE
-                            strokeJoin = Paint.Join.ROUND
-                            strokeCap = Paint.Cap.ROUND
-                            strokeWidth = strokeWidthPx
-                            isAntiAlias = true
-                        }
-                        val pointsToRender = strokes + activeStroke.let { if (it.isEmpty()) emptyList() else listOf(it) }
-                        pointsToRender.forEach { points ->
-                            if (points.size == 1) {
-                                canvas.drawPoint(points.first().x, points.first().y, paint)
-                            } else if (points.size > 1) {
-                                val path = Path().apply {
-                                    moveTo(points.first().x, points.first().y)
-                                    points.drop(1).forEach { point ->
-                                        lineTo(point.x, point.y)
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = {
+                            if (undoStack.isNotEmpty()) {
+                                val action = undoStack.removeAt(undoStack.lastIndex)
+                                when (action) {
+                                    is DrawAction.StrokeAction -> {
+                                        val index = strokes.indexOfLast { it == action.stroke }
+                                        if (index >= 0) {
+                                            strokes.removeAt(index)
+                                        }
+                                        redoStack.add(action)
+                                    }
+                                    is DrawAction.TextAction -> {
+                                        val index = textItems.indexOfLast { it == action.textItem }
+                                        if (index >= 0) {
+                                            textItems.removeAt(index)
+                                        }
+                                        redoStack.add(action)
                                     }
                                 }
-                                canvas.drawPath(path, paint)
                             }
+                        }) {
+                            Text("Undo")
                         }
-                        val output = ByteArrayOutputStream()
-                        bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
-                        onSave(output.toByteArray())
-                    }) {
-                        Text("Save")
+                        OutlinedButton(onClick = {
+                            if (redoStack.isNotEmpty()) {
+                                val action = redoStack.removeAt(redoStack.lastIndex)
+                                when (action) {
+                                    is DrawAction.StrokeAction -> {
+                                        strokes.add(action.stroke)
+                                        undoStack.add(action)
+                                    }
+                                    is DrawAction.TextAction -> {
+                                        textItems.add(action.textItem)
+                                        undoStack.add(action)
+                                    }
+                                }
+                            }
+                        }) {
+                            Text("Redo")
+                        }
+                        OutlinedButton(onClick = {
+                            strokes.clear()
+                            textItems.clear()
+                            activeStroke = null
+                            undoStack.clear()
+                            redoStack.clear()
+                        }) {
+                            Text("Clear")
+                        }
                     }
+                    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        OutlinedButton(onClick = onDismiss) {
+                            Text("Cancel")
+                        }
+                        Button(onClick = {
+                            if (canvasSize.width <= 0 || canvasSize.height <= 0 ||
+                                (strokes.isEmpty() && activeStroke == null && textItems.isEmpty())
+                            ) {
+                                onDismiss()
+                                return@Button
+                            }
+                            val bitmap = Bitmap.createBitmap(
+                                canvasSize.width,
+                                canvasSize.height,
+                                Bitmap.Config.ARGB_8888,
+                            )
+                            val canvas = AndroidCanvas(bitmap)
+                            canvas.drawColor(AndroidColor.WHITE)
+                            val allStrokesForBitmap = buildList {
+                                addAll(strokes)
+                                activeStroke?.let { add(it) }
+                            }
+                            allStrokesForBitmap.forEach { stroke ->
+                                val paint = Paint().apply {
+                                    color = stroke.color.toArgb()
+                                    style = Paint.Style.STROKE
+                                    strokeJoin = Paint.Join.ROUND
+                                    strokeCap = Paint.Cap.ROUND
+                                    strokeWidth = stroke.strokeWidth
+                                    isAntiAlias = true
+                                }
+                                val points = stroke.points
+                                if (points.size == 1) {
+                                    canvas.drawPoint(points.first().x, points.first().y, paint)
+                                } else if (points.size > 1) {
+                                    val path = Path().apply {
+                                        moveTo(points.first().x, points.first().y)
+                                        points.drop(1).forEach { point ->
+                                            lineTo(point.x, point.y)
+                                        }
+                                    }
+                                    canvas.drawPath(path, paint)
+                                }
+                            }
+                            textItems.forEach { textItem ->
+                                val paint = Paint().apply {
+                                    color = textItem.color.toArgb()
+                                    style = Paint.Style.FILL
+                                    textSize = with(density) { 16.sp.toPx() }
+                                    isAntiAlias = true
+                                }
+                                canvas.drawText(
+                                    textItem.text,
+                                    textItem.position.x,
+                                    textItem.position.y,
+                                    paint,
+                                )
+                            }
+                            val output = ByteArrayOutputStream()
+                            bitmap.compress(Bitmap.CompressFormat.PNG, 100, output)
+                            onSave(output.toByteArray())
+                        }) {
+                            Text("Save")
+                        }
+                    }
+                }
+                if (showTextDialog) {
+                    AlertDialog(
+                        onDismissRequest = {
+                            showTextDialog = false
+                            pendingText = ""
+                        },
+                        title = { Text("Add text") },
+                        text = {
+                            Column {
+                                TextField(
+                                    value = pendingText,
+                                    onValueChange = { pendingText = it },
+                                    label = { Text("Text") },
+                                )
+                                Spacer(modifier = Modifier.height(8.dp))
+                                Text(text = "After confirming, tap on the sketch to place the text.")
+                            }
+                        },
+                        confirmButton = {
+                            Button(onClick = {
+                                if (pendingText.isNotBlank()) {
+                                    isPlacingText = true
+                                    showTextDialog = false
+                                }
+                            }) {
+                                Text("Place")
+                            }
+                        },
+                        dismissButton = {
+                            OutlinedButton(onClick = {
+                                showTextDialog = false
+                                pendingText = ""
+                            }) {
+                                Text("Cancel")
+                            }
+                        },
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add stroke color selection, thickness slider, and clear action to the sketch pad dialog
- support undo/redo history for strokes and annotations and keep drawings when saving
- allow adding text annotations to sketches and include them in the exported bitmap

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: Build-tool 34.0.0 has corrupt source.properties at /root/.android-sdk/build-tools/34.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e3511c19848320b60f39cc8269e49f