### PR TITLE
Stop automatic summarizer asset generation

### DIFF
--- a/scripts/generate_summarizer_assets.py
+++ b/scripts/generate_summarizer_assets.py
@@ -1,10 +1,6 @@
-"""Utility script for android-ci workflow to generate summarizer assets."""
+"""Utility script to verify summarizer assets required by the Android build."""
 from __future__ import annotations
 
-import importlib
-import os
-import subprocess
-import sys
 from pathlib import Path
 
 
@@ -13,26 +9,6 @@ REQUIRED_ASSET_RELATIVE_PATHS = [
     Path("app/src/main/assets/decoder_step_int8_dynamic.tflite"),
     Path("app/src/main/assets/tokenizer.json"),
 ]
-
-
-class TensorFlowUnavailableError(RuntimeError):
-    """Raised when TensorFlow (or its dependencies) cannot be imported."""
-
-
-def _ensure_package(module_name: str, *, package: str | None = None) -> None:
-    """Install ``package`` via pip if ``module_name`` cannot be imported."""
-
-    try:
-        importlib.import_module(module_name)
-    except ModuleNotFoundError:
-        install_target = package or module_name
-        subprocess.check_call([sys.executable, "-m", "pip", "install", install_target])
-        try:
-            importlib.import_module(module_name)
-        except ModuleNotFoundError as exc:  # pragma: no cover - sanity guard
-            raise TensorFlowUnavailableError(
-                f"Module '{module_name}' is unavailable even after installation"
-            ) from exc
 
 
 def _repo_root() -> Path:
@@ -48,64 +24,13 @@ def _resolve_required_asset_paths() -> list[Path]:
 
 
 def _report_missing_assets(missing_paths: list[Path]) -> None:
-    print("Summarizer assets missing; regenerating via build_tensor.ipynb:")
+    print("⚠️  Summarizer assets missing from the repository:")
     for path in missing_paths:
         print(f"  - {path.relative_to(_repo_root())}")
-
-
-def _generate_with_tensorflow() -> None:
-    os.environ.setdefault("TF_USE_LEGACY_KERAS", "1")
-
-    required_packages = {
-        "tensorflow": "tensorflow==2.19.0",
-        "tf_keras": "tf-keras==2.19.0",
-        "sentencepiece": None,
-        "transformers": "transformers==4.44.2",
-        "huggingface_hub": "huggingface_hub>=0.24.0",
-        "numpy": "numpy==2.0.2",
-        "google.protobuf": "protobuf==5.29.1",
-        "ml_dtypes": "ml-dtypes>=0.5.0",
-        "datasets": "datasets==3.1.0",
-    }
-
-    for module_name, package_spec in required_packages.items():
-        try:
-            _ensure_package(module_name, package=package_spec)
-        except subprocess.CalledProcessError as exc:
-            raise TensorFlowUnavailableError(
-                f"Failed to install dependency for '{module_name}'"
-            ) from exc
-
-    notebook = _repo_root() / "build_tensor.ipynb"
-    if not notebook.exists():
-        raise FileNotFoundError("build_tensor.ipynb not found")
-
-    # Ensure working directory is repo root before generating assets
-    os.chdir(_repo_root())
-
-    filtered_lines: list[str] = []
-    skip_continuation = False
-    for line in notebook.read_text().splitlines():
-        stripped = line.lstrip()
-
-        if skip_continuation:
-            skip_continuation = stripped.endswith("\\")
-            continue
-
-        if stripped.startswith("%pip"):
-            skip_continuation = stripped.endswith("\\")
-            continue
-
-        filtered_lines.append(line)
-
-    code = compile("\n".join(filtered_lines), str(notebook), "exec")
-    globals_dict = {"__name__": "__main__"}
-    try:
-        exec(code, globals_dict)
-    except ModuleNotFoundError as exc:
-        raise TensorFlowUnavailableError(
-            "TensorFlow dependencies missing while executing build_tensor.ipynb"
-        ) from exc
+    print(
+        "    These models are produced offline and must be added manually before running "
+        "ML-dependent features or tests."
+    )
 
 
 def main() -> None:
@@ -117,15 +42,7 @@ def main() -> None:
         return
 
     _report_missing_assets(missing_paths)
-
-    _generate_with_tensorflow()
-
-    remaining_missing = [path for path in required_paths if not path.exists()]
-    if remaining_missing:
-        missing_display = ", ".join(str(path.relative_to(_repo_root())) for path in remaining_missing)
-        raise RuntimeError(f"Failed to generate required summarizer assets: {missing_display}")
-
-    print("Summarizer assets generated successfully.")
+    raise SystemExit(1)
 
 
 if __name__ == "__main__":

--- a/setup_persist.sh
+++ b/setup_persist.sh
@@ -53,20 +53,23 @@ EOF
 # ----------------------------
 ASSETS_DIR="$PROJECT_DIR/app/src/main/assets"
 REQUIRED_ASSETS=("encoder_int8_dynamic.tflite" "decoder_step_int8_dynamic.tflite" "tokenizer.json")
-MISSING_ASSETS=0
 
+MISSING_ASSETS=()
 for asset in "${REQUIRED_ASSETS[@]}"; do
   if [ ! -f "$ASSETS_DIR/$asset" ]; then
-    MISSING_ASSETS=1
-    break
+    MISSING_ASSETS+=("$asset")
   fi
 done
 
-if [ "$MISSING_ASSETS" -eq 1 ]; then
-  echo "🧩 Required ML assets missing. Generating assets via Python script..."
-  python3 "$PROJECT_DIR/scripts/generate_summarizer_assets.py"
+if [ "${#MISSING_ASSETS[@]}" -gt 0 ]; then
+  echo "⚠️  Missing summarizer assets detected in $ASSETS_DIR:"
+  for asset in "${MISSING_ASSETS[@]}"; do
+    echo "   - $asset"
+  done
+  echo "   The summariser models are generated offline and must be uploaded manually."
+  echo "   Please copy the required files into the assets directory before running ML-dependent features."
 else
-  echo "✅ All ML assets present in $ASSETS_DIR. Skipping asset generation and heavy Python dependency installation."
+  echo "✅ All ML assets present in $ASSETS_DIR."
 fi
 
 # ----------------------------


### PR DESCRIPTION
## Summary
- update the setup script to warn about missing summarizer assets instead of attempting to build them
- simplify the summarizer asset helper script to require manual model uploads and remove TensorFlow dependencies

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e386f9cb648320964820e14207b256