### PR TITLE
Fix missing nativeCanvas import

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SketchPadDialog.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.nativeCanvas
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.pointerInput


### PR DESCRIPTION
## Summary
- add the Compose graphics nativeCanvas import used by SketchPadDialog

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing android-34 SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5faa2ad348320937616b60988434e