### PR TITLE
Improve summarizer fallback formatting and logging

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -747,7 +747,10 @@ class NoteViewModel(
 
     private fun sanitizeSummary(summary: String): String {
         val stripped = attachmentTagRegex.replace(summary, " ")
-        return stripped.replace(Regex("\\s+"), " ").trim()
+        val sanitizedLines = stripped
+            .split('\n')
+            .map { line -> line.replace(Regex("\\s+"), " ").trim() }
+        return sanitizedLines.joinToString("\n").trim()
     }
 
     private data class ProcessedNoteContent(


### PR DESCRIPTION
## Summary
- update the summarizer fallback to strip injected titles, limit output to the first 150 characters, split it across two lines, and emit explicit fallback reasons for debug notes
- preserve multi-line summaries when sanitising stored values so the fallback formatting survives persistence
- extend the summarizer unit tests to cover the new fallback behaviour

## Testing
- ./gradlew test --console=plain --no-daemon *(fails: NDK is not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68e5ff893a408320af4208d4bd77ab09