### PR TITLE
Align TensorFlow Lite dependencies with available artifacts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation("org.tensorflow:tensorflow-lite:2.17.0") {
+    implementation("org.tensorflow:tensorflow-lite:2.16.1") {
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
     implementation("org.tensorflow:tensorflow-lite-support:0.4.4") {
@@ -176,8 +176,8 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
-    implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:2.17.0'
-    implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
+    implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:2.16.1'
+    implementation 'org.tensorflow:tensorflow-lite-api:2.16.1'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
     implementation 'ai.djl.android:tokenizer-native:0.33.0'
@@ -192,7 +192,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-    testImplementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
+    testImplementation 'org.tensorflow:tensorflow-lite-api:2.16.1'
     testImplementation 'org.json:json:20240303'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.2'


### PR DESCRIPTION
## Summary
- align TensorFlow Lite implementation and test dependencies on version 2.16.1
- resolve build failure caused by missing tensorflow-lite-select-tf-ops 2.17.0 artifact

## Testing
- ./gradlew help --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68e60f0dfa248320bb7391c794fdd971