### PR TITLE
Upgrade TensorFlow Lite to 2.17.0 and fix native merge conflicts

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -136,6 +136,16 @@ android {
         }
         jniLibs {
             useLegacyPackaging true
+            // The TensorFlow Lite runtime, select TF ops, and flex delegate AARs
+            // all package identically named native libraries.  When Gradle merges
+            // the JNI folders without explicit guidance it surfaces duplicate file
+            // errors for libtensorflowlite_jni.so / libtensorflowlite_flex_jni.so on
+            // select build variants.  Prefer the copies that ship with the runtime
+            // dependency to avoid the merge failure that triggered the earlier
+            // rollback to 2.16.1.
+            pickFirst '**/libtensorflowlite_jni.so'
+            pickFirst '**/libtensorflowlite_flex_jni.so'
+            pickFirst '**/libtensorflowlite_select_tf_ops.so'
         }
     }
 
@@ -165,7 +175,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.12.0' // Or the latest version
     implementation 'androidx.exifinterface:exifinterface:1.3.7'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3'
-    implementation("org.tensorflow:tensorflow-lite:2.16.1") {
+    implementation("org.tensorflow:tensorflow-lite:2.17.0") {
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
     implementation("org.tensorflow:tensorflow-lite-support:0.4.4") {
@@ -176,8 +186,11 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite-support-api"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
-    implementation 'org.tensorflow:tensorflow-lite-select-tf-ops:2.16.1'
-    implementation 'org.tensorflow:tensorflow-lite-api:2.16.1'
+    implementation('org.tensorflow:tensorflow-lite-select-tf-ops:2.17.0') {
+        exclude group: "org.tensorflow", module: "tensorflow-lite"
+        exclude group: "org.tensorflow", module: "tensorflow-lite-api"
+    }
+    implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
     implementation 'ai.djl.android:tokenizer-native:0.33.0'
@@ -192,7 +205,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-inline:5.2.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.1.0'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3'
-    testImplementation 'org.tensorflow:tensorflow-lite-api:2.16.1'
+    testImplementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     testImplementation 'org.json:json:20240303'
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
     testImplementation 'androidx.lifecycle:lifecycle-runtime-testing:2.6.2'
@@ -264,5 +277,15 @@ tasks.withType(MergeNativeLibsTask).configureEach { task ->
         def outputDir = task.outputDir.get().asFile
         def alignedLibraries = gradleProject.fileTree(dir: outputDir, include: ['**/*.so']).files
         alignNativeLibrariesAction(gradleProject, alignedLibraries)
+    }
+}
+
+configurations.configureEach { configuration ->
+    configuration.resolutionStrategy.eachDependency { details ->
+        if (details.requested.group == 'org.tensorflow') {
+            if (details.requested.name in ['tensorflow-lite', 'tensorflow-lite-api', 'tensorflow-lite-select-tf-ops']) {
+                details.useVersion '2.17.0'
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- bump the TensorFlow Lite runtime, API, and select TF ops dependencies back to 2.17.0 so FULLY_CONNECTED v12 kernels are available
- add packaging directives and resolution strategy overrides to keep the TensorFlow Lite artifacts on a consistent 2.17.0 stack and avoid duplicate native library merge failures that previously forced the rollback

## Testing
- ./gradlew test --console=plain *(fails: NDK is not installed in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e61c88473483209e9d86ef0e95a22d