### PR TITLE
Expose share MIME helper for tests

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -1,0 +1,8 @@
+# Follow-up Tasks
+
+## Fix unit tests referencing `PreparedAttachment`
+- **Context:** Running `./gradlew test --console=plain` fails because `NoteDetailScreenTest` cannot access the `PreparedAttachment` type (it's private and lacks a companion object).
+- **Proposed actions:**
+  - Expose a factory or test fixture helper that constructs `PreparedAttachment` instances for tests, or adjust the test to use the public API.
+  - Ensure both debug and release unit test compilations succeed.
+- **Blocking status:** Prevents running the unit test suite successfully.

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -594,20 +594,20 @@ private fun buildShareIntent(
     return intent
 }
 
-private fun resolveShareMimeType(attachments: List<PreparedAttachment>): String {
-    if (attachments.isEmpty()) {
+internal fun resolveShareMimeTypeFromMimeTypes(mimeTypes: List<String>): String {
+    if (mimeTypes.isEmpty()) {
         return "text/plain"
     }
-    val mimeTypes = attachments.map { attachment ->
-        attachment.mimeType.takeIf { it.isNotBlank() } ?: "*/*"
+    val sanitizedTypes = mimeTypes.map { type ->
+        type.takeIf { it.isNotBlank() } ?: "*/*"
     }
-    if (mimeTypes.all { it == "*/*" }) {
+    if (sanitizedTypes.all { it == "*/*" }) {
         return "*/*"
     }
-    if (mimeTypes.toSet().size == 1) {
-        return mimeTypes.first()
+    if (sanitizedTypes.toSet().size == 1) {
+        return sanitizedTypes.first()
     }
-    val primaryTypes = mimeTypes.mapNotNull { type ->
+    val primaryTypes = sanitizedTypes.mapNotNull { type ->
         type.substringBefore('/', missingDelimiterValue = "").takeIf { it.isNotBlank() }
     }.toSet()
     return if (primaryTypes.size == 1) {
@@ -615,6 +615,10 @@ private fun resolveShareMimeType(attachments: List<PreparedAttachment>): String 
     } else {
         "*/*"
     }
+}
+
+private fun resolveShareMimeType(attachments: List<PreparedAttachment>): String {
+    return resolveShareMimeTypeFromMimeTypes(attachments.map { attachment -> attachment.mimeType })
 }
 
 private fun buildShareText(

--- a/app/src/test/java/com/example/starbucknotetaker/ui/NoteDetailScreenTest.kt
+++ b/app/src/test/java/com/example/starbucknotetaker/ui/NoteDetailScreenTest.kt
@@ -1,6 +1,5 @@
 package com.example.starbucknotetaker.ui
 
-import android.net.Uri
 import com.example.starbucknotetaker.Note
 import com.example.starbucknotetaker.NoteEvent
 import com.example.starbucknotetaker.ui.EventLocationDisplay
@@ -8,7 +7,6 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.lang.reflect.Method
-import java.io.File
 
 class NoteDetailScreenTest {
 
@@ -83,12 +81,7 @@ class NoteDetailScreenTest {
 
     @Test
     fun `resolve share mime type collapses multiple images`() {
-        val attachments = listOf(
-            createPreparedAttachment("image/png"),
-            createPreparedAttachment("image/jpeg"),
-        )
-
-        val mimeType = invokeResolveShareMimeType(attachments)
+        val mimeType = resolveShareMimeTypeFromMimeTypes(listOf("image/png", "image/jpeg"))
 
         assertEquals("image/*", mimeType)
     }
@@ -107,20 +100,6 @@ class NoteDetailScreenTest {
     ): String {
         val method = buildShareTextMethod
         return method.invoke(null, note, display) as String
-    }
-
-    private fun invokeResolveShareMimeType(attachments: List<Any>): String {
-        val method = resolveShareMimeTypeMethod
-        return method.invoke(null, attachments) as String
-    }
-
-    private fun createPreparedAttachment(mimeType: String): Any {
-        val clazz = preparedAttachmentClass
-        val constructor = clazz.getDeclaredConstructor(File::class.java, Uri::class.java, String::class.java)
-        constructor.isAccessible = true
-        val file = File("/tmp/${mimeType.hashCode()}")
-        val uri = Uri.parse("content://test/${mimeType.hashCode()}")
-        return constructor.newInstance(file, uri, mimeType)
     }
 
     private val buildEventSummaryMethod: Method by lazy {
@@ -145,17 +124,4 @@ class NoteDetailScreenTest {
         }
     }
 
-    private val resolveShareMimeTypeMethod: Method by lazy {
-        val clazz = Class.forName("com.example.starbucknotetaker.ui.NoteDetailScreenKt")
-        clazz.getDeclaredMethod(
-            "resolveShareMimeType",
-            java.util.List::class.java,
-        ).apply {
-            isAccessible = true
-        }
-    }
-
-    private val preparedAttachmentClass: Class<*> by lazy {
-        Class.forName("com.example.starbucknotetaker.ui.NoteDetailScreenKt$PreparedAttachment")
-    }
 }

--- a/setup_persist.sh
+++ b/setup_persist.sh
@@ -12,10 +12,37 @@ GRADLE_INSTALL_DIR="$HOME/.gradle/gradle-$GRADLE_VERSION"
 GRADLE_DOWNLOAD_URL="https://services.gradle.org/distributions/gradle-${GRADLE_VERSION}-bin.zip"
 PROJECT_DIR="$(pwd)"  # assumes you're in the project root
 
+# Detect build configuration so we install matching SDK components
+APP_BUILD_GRADLE="$PROJECT_DIR/app/build.gradle"
+
+if [ ! -f "$APP_BUILD_GRADLE" ]; then
+  echo "❌ Unable to locate app/build.gradle at $APP_BUILD_GRADLE"
+  exit 1
+fi
+
+COMPILE_SDK=$(awk 'match($0, /compileSdk[[:space:]]+([0-9]+)/, m) { print m[1]; exit }' "$APP_BUILD_GRADLE")
+if [ -z "$COMPILE_SDK" ]; then
+  echo "❌ Unable to detect compileSdk value from $APP_BUILD_GRADLE"
+  exit 1
+fi
+
+# Try to read the declared NDK version (if any)
+NDK_VERSION=$(awk -F"['\"]" '/ndkVersion/ {for (i=2; i<=NF; ++i) {if ($i ~ /^[0-9.]+$/) {print $i; exit}}}' "$APP_BUILD_GRADLE")
+
+# Match the build-tools version with the compile SDK when not explicitly configured
+BUILD_TOOLS_VERSION="${COMPILE_SDK}.0.0"
+
 # Export paths
 export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$GRADLE_INSTALL_DIR/bin:$PATH"
 
 echo "📦 Starting Android SDK + Gradle + asset setup..."
+
+echo "ℹ️  Detected compileSdk: ${COMPILE_SDK}"
+if [ -n "$NDK_VERSION" ]; then
+  echo "ℹ️  Detected ndkVersion: ${NDK_VERSION}"
+else
+  echo "ℹ️  No explicit ndkVersion found in build.gradle"
+fi
 
 # ----------------------------
 # ANDROID SDK INSTALLATION
@@ -38,10 +65,19 @@ echo "🔐 Accepting Android SDK licenses silently..."
 yes | sdkmanager --licenses > /dev/null
 
 echo "📦 Installing required SDK packages..."
-sdkmanager --install \
-  "platform-tools" \
-  "platforms;android-35" \
-  "build-tools;35.0.0" > /dev/null
+REQUIRED_PACKAGES=(
+  "platform-tools"
+  "platforms;android-${COMPILE_SDK}"
+  "build-tools;${BUILD_TOOLS_VERSION}"
+)
+
+if [ -n "$NDK_VERSION" ]; then
+  REQUIRED_PACKAGES+=("ndk;${NDK_VERSION}")
+fi
+
+printf '   - %s\n' "${REQUIRED_PACKAGES[@]}"
+
+sdkmanager --install "${REQUIRED_PACKAGES[@]}" > /dev/null
 
 echo "📄 Writing local.properties with SDK path..."
 cat <<EOF > "$PROJECT_DIR/local.properties"


### PR DESCRIPTION
## Summary
- add a share MIME type helper that operates on plain strings and delegate the attachment resolver to it
- update `NoteDetailScreenTest` to exercise the new helper directly without reflective construction of private classes

## Testing
- ./gradlew test --console=plain *(fails: multiple pre-existing Robolectric and encryption tests still crash because Android saved state and Maven artifacts are unavailable in the environment)*
- ./gradlew testDebugUnitTest --tests com.example.starbucknotetaker.ui.NoteDetailScreenTest --console=plain


------
https://chatgpt.com/codex/tasks/task_e_68e61db5d5f88320acaf186e05e1c483