### PR TITLE
Add TensorFlow Maven repository

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -15,6 +15,10 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven {
+            name = "TensorFlow"
+            url = uri('https://storage.googleapis.com/download.tensorflow.org/maven')
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add the TensorFlow Maven repository so Gradle can resolve the tensorflow-lite-select-tf-ops dependency

## Testing
- ./gradlew :app:assembleDebug --console=plain --no-daemon *(fails: NDK is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e6354d84848320b3162024ab2b8029