### PR TITLE
Fix lintDebug failure due to missing generated values

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,5 @@
 import com.android.build.gradle.internal.tasks.MergeNativeLibsTask
+import com.android.build.gradle.tasks.GenerateResValues
 import org.gradle.process.ExecSpec
 
 plugins {
@@ -77,6 +78,24 @@ def alignNativeLibrariesAction = { Project gradleProject, Collection<File> nativ
             spec.executable = 'python3'
             spec.args = [alignmentScript.absolutePath, library.absolutePath]
         }
+    }
+}
+
+def ensurePlaceholderResValues(File outputDir) {
+    if (outputDir == null) {
+        return
+    }
+
+    def valuesDir = new File(outputDir, 'values')
+    if (!valuesDir.exists() && !valuesDir.mkdirs()) {
+        throw new GradleException("Unable to create generated values directory at ${valuesDir}")
+    }
+
+    def valuesFile = new File(valuesDir, 'values.xml')
+    if (!valuesFile.exists()) {
+        valuesFile.text = '''<?xml version="1.0" encoding="utf-8"?>
+<resources/>
+'''
     }
 }
 
@@ -321,6 +340,12 @@ tasks.withType(MergeNativeLibsTask).configureEach { task ->
         def outputDir = task.outputDir.get().asFile
         def alignedLibraries = gradleProject.fileTree(dir: outputDir, include: ['**/*.so']).files
         alignNativeLibrariesAction(gradleProject, alignedLibraries)
+    }
+}
+
+tasks.withType(GenerateResValues).configureEach { task ->
+    task.doLast {
+        ensurePlaceholderResValues(task.resOutputDir)
     }
 }
 


### PR DESCRIPTION
## Summary
- add a helper that writes a minimal generated values.xml when res value outputs are empty
- hook all GenerateResValues tasks so lint can rely on the placeholder resources

## Testing
- ./gradlew clean lintDebug --console=plain --no-configuration-cache

------
https://chatgpt.com/codex/tasks/task_e_68e645531a1c8320828059cde4fccd83