### PR TITLE
Fix GenerateResValues placeholder helper

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -81,7 +81,7 @@ def alignNativeLibrariesAction = { Project gradleProject, Collection<File> nativ
     }
 }
 
-def ensurePlaceholderResValues(File outputDir) {
+def ensurePlaceholderResValuesAction = { File outputDir ->
     if (outputDir == null) {
         return
     }
@@ -345,7 +345,16 @@ tasks.withType(MergeNativeLibsTask).configureEach { task ->
 
 tasks.withType(GenerateResValues).configureEach { task ->
     task.doLast {
-        ensurePlaceholderResValues(task.resOutputDir)
+        def resOutput = task.resOutputDir
+        def outputDir = null
+        if (resOutput != null) {
+            try {
+                outputDir = resOutput.get().asFile
+            } catch (Throwable ignored) {
+                outputDir = resOutput instanceof File ? resOutput : null
+            }
+        }
+        ensurePlaceholderResValuesAction(outputDir)
     }
 }
 


### PR DESCRIPTION
## Summary
- register the placeholder resource generator as a closure instead of a Groovy method
- resolve the GenerateResValues output directory before invoking the helper to avoid missing method errors

## Testing
- ./gradlew :app:compileDebugKotlin --console=plain --no-daemon *(fails: existing Kotlin compilation errors in NoteListScreen.kt)*

------
https://chatgpt.com/codex/tasks/task_e_68e65008e56c832086cea2d40ae57dec