### PR TITLE
Fix missing anchored draggable imports

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteListScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.AnchoredDraggableState
 import androidx.compose.foundation.gestures.DraggableAnchors
 import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.anchor
+import androidx.compose.foundation.gestures.animateTo
 import androidx.compose.foundation.gestures.anchoredDraggable
+import androidx.compose.foundation.gestures.snapTo
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed


### PR DESCRIPTION
## Summary
- add the missing anchored draggable helper imports so swipe actions compile with the current Compose version

## Testing
- not run (Gradle dependency resolution was taking too long in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e658aeff848320869b0c7360b9aac3