### PR TITLE
Add toggle for AI-assisted summaries

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/AppSettings.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/AppSettings.kt
@@ -1,0 +1,21 @@
+package com.example.starbucknotetaker
+
+import android.content.Context
+import androidx.core.content.edit
+
+class AppSettings(context: Context) {
+    private val prefs =
+        context.applicationContext.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun isSummarizerEnabled(): Boolean =
+        prefs.getBoolean(KEY_SUMMARIZER_ENABLED, /* defaultValue = */ true)
+
+    fun setSummarizerEnabled(enabled: Boolean) {
+        prefs.edit { putBoolean(KEY_SUMMARIZER_ENABLED, enabled) }
+    }
+
+    private companion object {
+        private const val PREFS_NAME = "starbuck_settings"
+        private const val KEY_SUMMARIZER_ENABLED = "summarizer_enabled"
+    }
+}

--- a/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/MainActivity.kt
@@ -301,6 +301,7 @@ fun AppContent(
 ) {
     val context = LocalContext.current
     val summarizerState by noteViewModel.summarizerState.collectAsState()
+    val summarizerEnabled by noteViewModel.summarizerEnabled.collectAsState()
     val pendingShare by noteViewModel.pendingShare.collectAsState()
     val pendingOpenNoteId by noteViewModel.pendingOpenNoteId.collectAsState()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
@@ -556,6 +557,8 @@ fun AppContent(
                 pinManager = pinManager,
                 biometricEnabled = biometricsEnabled,
                 onBiometricChanged = { enabled -> biometricsEnabled = enabled },
+                summarizerEnabled = summarizerEnabled,
+                onSummarizerChanged = { enabled -> noteViewModel.setSummarizerEnabled(enabled) },
                 onBack = { navController.popBackStack() },
                 onImport = { uri, pin, overwrite -> noteViewModel.importNotes(context, uri, pin, overwrite) },
                 onExport = { uri -> noteViewModel.exportNotes(context, uri) },

--- a/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/SettingsScreen.kt
@@ -33,6 +33,8 @@ fun SettingsScreen(
     pinManager: PinManager,
     biometricEnabled: Boolean,
     onBiometricChanged: (Boolean) -> Unit,
+    summarizerEnabled: Boolean,
+    onSummarizerChanged: (Boolean) -> Unit,
     onBack: () -> Unit,
     onImport: (Uri, String, Boolean) -> Boolean,
     onExport: (Uri) -> Unit,
@@ -281,6 +283,31 @@ fun SettingsScreen(
                 exportLauncher.launch(name)
             }) {
                 Text("Export archived notes file")
+            }
+            Divider()
+            Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text("AI-assisted summaries", style = MaterialTheme.typography.h6)
+                        Text(
+                            "Use the on-device model to generate note previews.",
+                            style = MaterialTheme.typography.body2
+                        )
+                    }
+                    Switch(
+                        checked = summarizerEnabled,
+                        onCheckedChange = onSummarizerChanged
+                    )
+                }
+                Text(
+                    text = if (summarizerEnabled) {
+                        "New and edited notes receive AI-enhanced summaries."
+                    } else {
+                        "When off, previews show the first two lines of the note instead."
+                    },
+                    style = MaterialTheme.typography.caption,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
             }
             Divider()
             Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {


### PR DESCRIPTION
## Summary
- add a persisted application setting that tracks whether AI-assisted summaries are enabled
- expose the preference in the Settings screen with a switch and route the state through the navigation host
- update `NoteViewModel` to respect the toggle by skipping summarizer work when disabled and using the first two note lines as a manual summary

## Testing
- ./gradlew :app:testDebugUnitTest --console=plain --no-daemon --no-configuration-cache *(fails in this environment: Robolectric/Android keystore initialization errors)*

------
https://chatgpt.com/codex/tasks/task_e_68e665609d508320ace6fae11a68c12f