### PR TITLE
Fix manifest namespace warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,7 +239,8 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
-    implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
+    // Provide the Java API stubs without packaging a duplicate manifest namespace.
+    compileOnly 'org.tensorflow:tensorflow-lite-api:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
     implementation 'ai.djl.android:tokenizer-native:0.33.0'

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.example.starbucknotetaker">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
## Summary
- remove the deprecated package attribute from the Android manifest so the Gradle namespace setting is respected
- change the TensorFlow Lite API dependency to compileOnly to prevent duplicate namespace packaging warnings while keeping the stubs for compilation

## Testing
- ./gradlew --console=plain -i :app:assembleDebug --no-daemon

------
https://chatgpt.com/codex/tasks/task_e_68e6698d978083209b54a9dd9d40684a