### PR TITLE
Fix TensorFlow Lite runtime dependency resolution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -239,8 +239,8 @@ dependencies {
         exclude group: "org.tensorflow", module: "tensorflow-lite"
         exclude group: "org.tensorflow", module: "tensorflow-lite-api"
     }
-    // Provide the Java API stubs without packaging a duplicate manifest namespace.
-    compileOnly 'org.tensorflow:tensorflow-lite-api:2.17.0'
+    // Provide the TensorFlow Lite Java API at runtime so InterpreterImpl$Option is available.
+    implementation 'org.tensorflow:tensorflow-lite-api:2.17.0'
     implementation "com.squareup.okhttp3:okhttp:4.12.0"
     implementation 'androidx.work:work-runtime-ktx:2.9.0'
     implementation 'ai.djl.android:tokenizer-native:0.33.0'


### PR DESCRIPTION
## Summary
- include the TensorFlow Lite API runtime dependency so InterpreterImpl$Option is packaged with the app

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e684909ff883208c9c2187d59e3fc6