### PR TITLE
Fix Compose compile errors in checklist drag UI

### DIFF
--- a/app/src/main/java/com/example/starbucknotetaker/ui/ChecklistScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/ChecklistScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import android.widget.Toast
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.animateItemPlacement
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
@@ -73,6 +72,7 @@ fun EditChecklistScreen(
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ChecklistEditorScreen(
     topBarTitle: String,
@@ -293,7 +293,6 @@ private fun ChecklistEditorScreen(
                         requestFocus = pendingFocusId == item.id,
                         onFocusHandled = { pendingFocusId = null },
                         modifier = Modifier
-                            .animateItemPlacement()
                             .onSizeChanged { size -> itemHeights[item.id] = size.height }
                             .graphicsLayer {
                                 if (isDragging) {

--- a/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/ui/NoteDetailScreen.kt
@@ -12,6 +12,7 @@ import android.provider.MediaStore
 import android.util.Base64
 import android.util.Patterns
 import android.widget.Toast
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.background
@@ -38,6 +39,7 @@ import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -445,6 +447,7 @@ fun NoteDetailScreen(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun ChecklistDetailSection(
     noteId: Long,


### PR DESCRIPTION
### Motivation
- The build was failing with unresolved Compose references (`animateItemPlacement`, `graphicsLayer`, etc.) caused by mismatched or unavailable Compose APIs and missing opt-ins for experimental drag gestures; the change aims to restore successful Kotlin compilation for checklist-related UI.

### Description
- Removed the unavailable `animateItemPlacement` import and call in `app/src/main/java/com/example/starbucknotetaker/ui/ChecklistScreen.kt` to avoid the unresolved reference.
- Added `@OptIn(ExperimentalFoundationApi::class)` to `ChecklistEditorScreen` and `ChecklistDetailSection` to explicitly opt into the experimental drag APIs used by the checklist UI.
- Added the missing `ExperimentalFoundationApi` and `graphicsLayer` imports to `NoteDetailScreen.kt` so drag/graphics modifiers compile correctly.

### Testing
- Attempted to sync with `origin/main` but the remote was not configured in the environment, so full repo sync could not be performed (command run: `git fetch origin && git reset --hard origin/main && git clean -fd`).
- Ran `./gradlew --console=plain :app:compileDebugKotlin` and the Kotlin compilation completed successfully after the changes. 
- The repository changes were committed locally and the modified files show the applied edits; automated compile check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbe31ccc6c8320b7f5e214f1e639f2)