### PR TITLE
[codex] align MLC-LLM deployment references

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir -p "$ASSETS_DIR"
 
           # category_mapping.json is retained for fallback heuristics.
-          # The Llama 3.1 8B model weights are downloaded at runtime (not bundled).
+          # The Llama 3.2 3B model weights are downloaded at runtime (not bundled).
           REQUIRED_FILES=(
             "category_mapping.json"
           )

--- a/README.md
+++ b/README.md
@@ -58,16 +58,30 @@ scripts/                           Repository helper scripts
 
 ### MLC model library (required before building)
 
-The compiled Llama 3.2 3B model library must be placed in `app/src/main/jniLibs/arm64-v8a/` before building:
+The compiled Llama 3.2 3B model library must be placed in `app/src/main/jniLibs/arm64-v8a/` before building.
+There is no prebuilt Android `.so` for this model in the public MLC release artifacts, so you must compile it locally:
 
 ```bash
-# 1. Download the MLC prebuilt APK
-#    https://github.com/mlc-ai/binary-mlc-llm-libs/releases/tag/Android-09262024
-# 2. Extract the .so
-unzip mlc-chat.apk "lib/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so" -d extracted/
-# 3. Copy into the project
-cp extracted/lib/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so \
-   app/src/main/jniLibs/arm64-v8a/
+# Prerequisites:
+# - Python 3.10+
+# - Android NDK r27+
+# - pip install mlc-llm
+# - export ANDROID_NDK=~/Android/Sdk/ndk/<version>
+# - export TVM_NDK_CC=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android24-clang
+
+# 1. Download the quantised weights
+git clone https://huggingface.co/mlc-ai/Llama-3.2-3B-Instruct-q4f16_0-MLC
+
+# 2. Compile the model library for Android arm64
+mlc_llm compile \
+  ./Llama-3.2-3B-Instruct-q4f16_0-MLC \
+  --target android \
+  --device android:arm64-v8a \
+  -o Llama-3.2-3B-Instruct-q4f16_0-MLC-android.so
+
+# 3. Copy into the project (note the required "lib" prefix)
+cp Llama-3.2-3B-Instruct-q4f16_0-MLC-android.so \
+   app/src/main/jniLibs/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so
 ```
 
 The `.so` is the compiled model library (~MB range). Model **weights** (~2 GB) are downloaded automatically at runtime from HuggingFace on first use.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -238,7 +238,7 @@ dependencies {
     implementation 'ai.djl.huggingface:tokenizers:0.33.0'
     implementation 'androidx.security:security-crypto:1.1.0-alpha06'
     implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.1.0'
-    // MLC LLM Android SDK — provides MLCEngine with OpenAI-compatible API for Llama 3.1 8B
+    // MLC LLM Android SDK with OpenAI-compatible API for Llama 3.2 3B
     implementation 'ai.mlc.mlcllm:android:0.1.0'
 
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.4'
@@ -374,4 +374,3 @@ tasks.withType(Test).configureEach { testTask ->
     testTask.systemProperty 'robolectric.dependency.dir', depsDir
     testTask.environment 'ROBOLECTRIC_DEPENDENCY_DIR', depsDir
 }
-

--- a/app/src/androidTest/java/com/example/starbucknotetaker/SummarizerModelInstrumentationTest.kt
+++ b/app/src/androidTest/java/com/example/starbucknotetaker/SummarizerModelInstrumentationTest.kt
@@ -14,7 +14,7 @@ import org.junit.runner.RunWith
  * Instrumentation tests for [Summarizer] and [LlamaModelManager] running on a real device.
  *
  * These tests exercise the fallback rule-based path (always available) and the
- * model-manager state machine without requiring the 4.5 GB Llama 3.1 8B model
+ * model-manager state machine without requiring the ~2 GB Llama 3.2 3B model
  * to be present on the test device.
  */
 @RunWith(AndroidJUnit4::class)
@@ -55,7 +55,7 @@ class SummarizerModelInstrumentationTest {
     fun modelManager_statusIsMissingOnFreshDevice() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val manager = LlamaModelManager(context)
-        // On a CI/test device the 4.5 GB model is not present
+        // On a CI/test device the ~2 GB model is typically not present.
         val status = manager.modelStatus.value
         assertTrue(
             "Expected Missing or Present, got $status",
@@ -65,9 +65,9 @@ class SummarizerModelInstrumentationTest {
     }
 
     @Test
-    fun modelManager_hfRepo_targetsLlama31_8B() {
+    fun modelManager_hfRepo_targetsLlama32_3B() {
         assertTrue(
-            LlamaModelManager.HF_REPO_ID.contains("Llama-3.1-8B", ignoreCase = true)
+            LlamaModelManager.HF_REPO_ID.contains("Llama-3.2-3B", ignoreCase = true)
         )
     }
 }

--- a/app/src/main/aidl/com/example/starbucknotetaker/IQspmService.aidl
+++ b/app/src/main/aidl/com/example/starbucknotetaker/IQspmService.aidl
@@ -19,7 +19,7 @@ interface IQspmService {
     int warmUpSummarizer();
     void summarize(String text, IQspmSummaryCallback callback);
 
-    /** Rewrites the given text in a clean, professional style via Llama 3.1 8B. */
+    /** Rewrites the given text in a clean, professional style via Llama 3.2 3B. */
     void rewrite(String text, IQspmSummaryCallback callback);
 
     /** Answers the given question, optionally grounded in the provided context. */

--- a/app/src/main/assets/DEPLOYMENT_README.md
+++ b/app/src/main/assets/DEPLOYMENT_README.md
@@ -25,22 +25,25 @@ app/src/main/jniLibs/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so
 > generic TVM Java runtime (`libtvm4j_runtime_packed.so`), not this model library.
 > You must compile it yourself.
 
-**Prerequisites:** Python 3.10+, Android NDK r27+, and the `mlc-llm` Python package
-(`pip install mlc-llm`). Set `ANDROID_NDK` and `TVM_NDK_CC` as described at
+**Prerequisites:** Python 3.10+, Android NDK r27+, and the `mlc-llm` Python package.
+Set `ANDROID_NDK` and `TVM_NDK_CC` as described at
 <https://llm.mlc.ai/docs/install/index.html>.
 
 ```bash
-# 1. Download quantised weights
+# 1. Install MLC-LLM
+pip install mlc-llm
+
+# 2. Download quantised weights
 git clone https://huggingface.co/mlc-ai/Llama-3.2-3B-Instruct-q4f16_0-MLC
 
-# 2. Compile the model library for Android arm64
+# 3. Compile the model library for Android arm64
 mlc_llm compile \
   ./Llama-3.2-3B-Instruct-q4f16_0-MLC \
   --target android \
   --device android:arm64-v8a \
   -o Llama-3.2-3B-Instruct-q4f16_0-MLC-android.so
 
-# 3. Copy into the project (note the required "lib" prefix)
+# 4. Copy into the project (note the required "lib" prefix)
 cp Llama-3.2-3B-Instruct-q4f16_0-MLC-android.so \
    app/src/main/jniLibs/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so
 ```
@@ -81,4 +84,3 @@ When the model is unavailable (weights not yet downloaded, `.so` missing, or ins
 ## Legacy TFLite assets
 
 The files `note_classifier.tflite`, `tokenizer_vocabulary_v2.txt`, `category_mapping.json`, and `deployment_metadata.json` are retained in `app/src/main/assets/` as legacy artifacts from the previous TFLite classification path. They are no longer used at runtime.
-

--- a/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LiteInterpreter.kt
@@ -4,8 +4,8 @@ import java.nio.MappedByteBuffer
 
 /**
  * Retained as a compatibility stub so that any existing test code referencing
- * [LiteInterpreter] continues to compile.  The TFLite inference path has been
- * replaced by [LlamaEngine] (MLC LLM + Llama 3.1 8B); this interface is no
+ * [LiteInterpreter] continues to compile. The TFLite inference path has been
+ * replaced by [LlamaEngine] (MLC LLM + Llama 3.2 3B); this interface is no
  * longer used at runtime.
  */
 interface LiteInterpreter {

--- a/app/src/main/java/com/example/starbucknotetaker/LlamaEngine.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LlamaEngine.kt
@@ -18,8 +18,9 @@ import kotlinx.coroutines.withContext
  * Llama 3.2 3B Instruct (q4f16_0 quantisation).
  *
  * The MLC-compiled model library (`.so`) must be bundled in the APK's
- * `jniLibs/arm64-v8a/` folder.  Prebuilt libraries for Android are published at:
- * https://github.com/mlc-ai/binary-mlc-llm-libs/releases/tag/Android-09262024
+ * `jniLibs/arm64-v8a/` folder. There is no prebuilt Android `.so` for this
+ * model in the public MLC release artifacts, so it must be compiled locally
+ * from `mlc-ai/Llama-3.2-3B-Instruct-q4f16_0-MLC` and copied into the app.
  *
  * The model weights (~2 GB) are not bundled in the APK; they are downloaded
  * to `filesDir/models/Llama-3.2-3B-Instruct-q4f16_0-MLC/` via [LlamaModelManager].
@@ -193,7 +194,7 @@ class LlamaEngine(private val context: Context) {
     }
 
     // ------------------------------------------------------------------
-    // Message construction (Llama 3.1 Instruct chat template)
+    // Message construction for the Llama 3.2 Instruct workflow
     // ------------------------------------------------------------------
 
     private fun buildMessages(

--- a/app/src/main/java/com/example/starbucknotetaker/LlamaModelManager.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/LlamaModelManager.kt
@@ -29,15 +29,16 @@ import java.util.concurrent.TimeUnit
  *   - `params_shard_*.bin`     — actual model weights (many shards)
  *
  * The compiled model library (`.so`) must be placed in the APK's
- * `jniLibs/arm64-v8a/` directory before building.  Extract it from the MLC
- * prebuilt release APK published at:
- * https://github.com/mlc-ai/binary-mlc-llm-libs/releases/tag/Android-09262024
+ * `jniLibs/arm64-v8a/` directory before building. There is no prebuilt Android
+ * `.so` for this model in the public MLC release artifacts, so it must be
+ * compiled locally from the HuggingFace weights with `mlc_llm compile`.
  *
  * Steps:
- *   1. Download `mlc-chat.apk` from the release above.
- *   2. Unzip: `unzip mlc-chat.apk "lib/arm64-v8a/libLlama-3.2-3B-Instruct-q4f16_0-MLC.so"`
- *   3. Copy the extracted `.so` to `app/src/main/jniLibs/arm64-v8a/`.
- *   4. Rebuild the project — Gradle will package the library automatically.
+ *   1. Install `mlc-llm` and configure `ANDROID_NDK` / `TVM_NDK_CC`.
+ *   2. Clone `https://huggingface.co/mlc-ai/Llama-3.2-3B-Instruct-q4f16_0-MLC`.
+ *   3. Run `mlc_llm compile ... --target android --device android:arm64-v8a`.
+ *   4. Copy the resulting `.so` to `app/src/main/jniLibs/arm64-v8a/`.
+ *   5. Rebuild the project — Gradle will package the library automatically.
  *
  * Usage:
  * ```
@@ -85,7 +86,7 @@ class LlamaModelManager(private val context: Context) {
     }
 
     /**
-     * Downloads all required Llama 3.1 8B MLC weight files from HuggingFace.
+     * Downloads all required Llama 3.2 3B MLC weight files from HuggingFace.
      *
      * Queries the HuggingFace tree API to get the full file listing (shard count
      * varies by quantisation), then fetches each file sequentially, reporting
@@ -284,7 +285,7 @@ class LlamaModelManager(private val context: Context) {
         /**
          * The model-library name passed to [ai.mlc.mlcllm.MLCEngine.reload].
          * This corresponds to the compiled `.so` bundled in the APK's `jniLibs/arm64-v8a/`.
-         * See the class KDoc for instructions on obtaining the prebuilt library.
+         * See the class KDoc for instructions on compiling and placing the library.
          */
         const val MODEL_LIB_NAME = "Llama-3.2-3B-Instruct-q4f16_0-MLC"
 

--- a/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/NoteViewModel.kt
@@ -874,7 +874,7 @@ class NoteViewModel(
     }
 
     /**
-     * Downloads the Llama 3.1 8B MLC model weights (~4.5 GB) from HuggingFace.
+     * Downloads the Llama 3.2 3B MLC model weights (~2 GB) from HuggingFace.
      * Progress is reflected in [modelStatus].
      */
     fun downloadAiModel() {

--- a/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
+++ b/app/src/main/java/com/example/starbucknotetaker/Summarizer.kt
@@ -10,9 +10,9 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicReference
 
 /**
- * On-device summariser backed by [LlamaEngine] (llama.cpp / GGUF model).
+ * On-device summariser backed by [LlamaEngine] (MLC LLM + Llama 3.2 3B).
  *
- * When the GGUF model has not been downloaded yet, or when the native library
+ * When the MLC model has not been downloaded yet, or when the native library
  * is unavailable, all inference automatically falls back to the lightweight
  * rule-based heuristics defined in this class — behaviour identical to the
  * previous TFLite path.
@@ -33,7 +33,7 @@ class Summarizer(
     /** Retained for source compatibility with existing tests; not used at runtime. */
     @Suppress("UNUSED_PARAMETER")
     private val interpreterFactory: (java.nio.MappedByteBuffer) -> LiteInterpreter = {
-        throw UnsupportedOperationException("LiteInterpreter not used in llama.cpp path")
+        throw UnsupportedOperationException("LiteInterpreter not used in MLC path")
     },
     private val logger: (String, Throwable) -> Unit = { msg, t -> Log.e("Summarizer", msg, t) },
     private val debugSink: (String) -> Unit = { msg -> Log.d("Summarizer", msg) },
@@ -71,7 +71,7 @@ class Summarizer(
     // ------------------------------------------------------------------
 
     /**
-     * Warms up the summariser engine.  When the GGUF model is present the
+     * Warms up the summariser engine. When the MLC model is present the
      * native context is initialised; otherwise the method returns [SummarizerState.Fallback]
      * to signal that heuristic summaries will be used.
      */

--- a/settings.gradle
+++ b/settings.gradle
@@ -15,7 +15,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
-        // MLC LLM Android SDK — provides MLCEngine for on-device Llama 3.1 8B inference
+        // MLC LLM Android SDK for on-device Llama 3.2 3B inference
         maven {
             name = "MlcLlm"
             url = uri('https://repo.mlc.ai/repository/maven-releases/')


### PR DESCRIPTION
## What changed

This PR aligns the MLC-LLM migration references across the repo so the documentation, inline runtime comments, and instrumentation expectations all point at the same Android setup.

It updates the project to consistently describe:
- `Llama-3.2-3B-Instruct-q4f16_0-MLC`
- local compilation of the Android `.so` via `mlc_llm compile`
- runtime download of the ~2 GB model weights from HuggingFace

## Why

Several files still mentioned the older `Llama 3.1 8B` path or suggested extracting a prebuilt library from `mlc-chat.apk`, which conflicted with the current `Llama 3.2 3B` integration and the documented Android compile flow.

## Impact

- Developers now get one consistent set of setup instructions for the Android MLC model library.
- Instrumentation coverage now asserts the correct HuggingFace repo target.
- Comments and AIDL/docs better match the actual runtime model configuration.

## Validation

Attempted:
- `./gradlew testDebugUnitTest --console=plain`
- `./gradlew assembleDebugAndroidTest --console=plain`

Both are currently blocked in this shell because the Android SDK is not configured for Gradle:
- `ANDROID_HOME` / `ANDROID_SDK_ROOT` were unset
- `local.properties` was missing
- the detected SDK path did not contain the required platform/build-tools packages
